### PR TITLE
Fix tiny_fiber shutdown correctness and dangling-pointer bugs

### DIFF
--- a/include/cortex/base_coroutine.hpp
+++ b/include/cortex/base_coroutine.hpp
@@ -56,7 +56,7 @@ protected:
      * @param resource The memory resource to use for stack and implementation allocation (default:
      * GetDefaultMemoryResource()).
      */
-    explicit BaseCoroutine(std::size_t stack_size_bytes = 262144,
+    explicit BaseCoroutine(std::size_t stack_size_bytes = Coroutine::kDefaultStackSizeBytes,
                            MemoryResourceSharedPtr resource = GetDefaultMemoryResource());
 
 private:

--- a/include/cortex/coroutine.hpp
+++ b/include/cortex/coroutine.hpp
@@ -84,8 +84,8 @@ public:
         Builder SetMemoryResource(MemoryResourceSharedPtr resource) && noexcept;
 
     private:
-        std::size_t stack_size_bytes_ {0};
-        MemoryResourceSharedPtr memory_resource_ {nullptr};
+        std::size_t stack_size_bytes_;
+        MemoryResourceSharedPtr memory_resource_;
     };
 
     Coroutine(const Coroutine&) = delete;

--- a/include/cortex/generator.hpp
+++ b/include/cortex/generator.hpp
@@ -74,7 +74,7 @@ public:
      * @throws std::invalid_argument if the body is empty or stack_size_bytes is 0 or resource is null.
      */
     static Generator Make(Body body,
-                          std::size_t stack_size_bytes = 262144,
+                          std::size_t stack_size_bytes = Coroutine::kDefaultStackSizeBytes,
                           MemoryResourceSharedPtr resource = GetDefaultMemoryResource()) {
         if (!static_cast<bool>(body)) {
             throw std::invalid_argument("generator body is null.");
@@ -99,7 +99,7 @@ public:
     struct Builder {
     public:
         Builder()
-            : stack_size_bytes_(262144)
+            : stack_size_bytes_(Coroutine::kDefaultStackSizeBytes)
             , memory_resource_(GetDefaultMemoryResource()) {}
 
         Generator Build(Body body) && {
@@ -117,8 +117,8 @@ public:
         }
 
     private:
-        std::size_t stack_size_bytes_ {0};
-        MemoryResourceSharedPtr memory_resource_ {nullptr};
+        std::size_t stack_size_bytes_;
+        MemoryResourceSharedPtr memory_resource_;
     };
 
     Generator(const Generator&) = delete;

--- a/include/cortex/tiny_fiber/condition_variable.hpp
+++ b/include/cortex/tiny_fiber/condition_variable.hpp
@@ -60,7 +60,9 @@ public:
     void NotifyAll();
 
 private:
-    std::deque<detail::Fiber*> waiters_;
+    // Stored by ID, not pointer, so stale entries (from Stop() or fiber death)
+    // can be safely detected and skipped on notify.
+    std::deque<detail::Fiber::Id> waiters_;
 };
 
 } // namespace cortex::tiny_fiber

--- a/include/cortex/tiny_fiber/detail/fiber.hpp
+++ b/include/cortex/tiny_fiber/detail/fiber.hpp
@@ -5,15 +5,15 @@
 #include <cortex/memory_resource.hpp>
 
 #include <cstdint>
-#include <exception>
-#include <memory>
 #include <vector>
 
 #include <function2/function2.hpp>
 
-namespace cortex::tiny_fiber::detail {
-
+namespace cortex::tiny_fiber {
 class Scheduler;
+} // namespace cortex::tiny_fiber
+
+namespace cortex::tiny_fiber::detail {
 
 // Internal fiber states
 enum class FiberState : std::uint8_t {
@@ -27,18 +27,13 @@ enum class FiberState : std::uint8_t {
 // Inherits from BaseCoroutine to get proper coroutine lifecycle management.
 // The user's function is stored and called from Continuation().
 class Fiber final : public BaseCoroutine {
-private:
-    struct PrivateTag {};
-
 public:
     using Id = std::uint64_t;
     using Body = fu2::unique_function<void()>;
 
-    // Create a new fiber with the given body, stack size, and memory resource.
-    static std::unique_ptr<Fiber> Make(Body body, std::size_t stack_size, MemoryResourceSharedPtr resource);
-
-    // Constructor is public but requires PrivateTag (only Make can call it)
-    Fiber(PrivateTag, Id id, Body body, std::size_t stack_size, MemoryResourceSharedPtr resource);
+    // Construction goes through Scheduler::SpawnFiberInternal so the scheduler can
+    // assign unique IDs. The constructor takes the ID directly.
+    Fiber(Id id, Body body, std::size_t stack_size, MemoryResourceSharedPtr resource);
 
     ~Fiber() override = default;
 
@@ -55,18 +50,6 @@ public:
         return state_ == FiberState::Suspended;
     }
 
-    [[nodiscard]] bool HasException() const noexcept {
-        return exception_ != nullptr;
-    }
-
-    [[nodiscard]] std::exception_ptr GetException() const noexcept {
-        return exception_;
-    }
-
-    void SetException(std::exception_ptr ex) noexcept {
-        exception_ = std::move(ex);
-    }
-
     // Run this fiber (Ready -> Running, resumes coroutine execution)
     void Run();
 
@@ -79,11 +62,12 @@ public:
     // Wake a parked fiber (Suspended -> Ready)
     void Wake();
 
-    // Mark fiber as finished and return its waiters (Running -> Finished)
-    std::vector<Fiber*> Complete();
+    // Mark fiber as finished and return the IDs of fibers waiting on it.
+    // IDs (not pointers) so callers can validate liveness via Scheduler::GetFiber.
+    std::vector<Id> Complete();
 
-    // Add a fiber that is waiting for this fiber to finish
-    void AddWaiter(Fiber* waiter);
+    // Add the ID of a fiber that is waiting for this fiber to finish.
+    void AddWaiter(Id waiter_id);
 
 private:
     void Continuation(CoroutineSuspendContext& ctx) override;
@@ -96,8 +80,7 @@ private:
     FiberState state_ {FiberState::Ready};
     Body body_;
     CoroutineSuspendContext* suspend_ctx_ {nullptr};
-    std::exception_ptr exception_ {nullptr};
-    std::vector<Fiber*> waiters_;
+    std::vector<Id> waiters_;
 };
 
 } // namespace cortex::tiny_fiber::detail

--- a/include/cortex/tiny_fiber/future.hpp
+++ b/include/cortex/tiny_fiber/future.hpp
@@ -56,9 +56,13 @@ public:
 
     Future& operator=(Future&& other) noexcept {
         if (this != &other) {
-            // Wait for current fiber if needed
+            // WaitImpl can throw SchedulerStoppingError; swallow it here since
+            // operator= is noexcept and we're abandoning the old state anyway.
             if (state_ && scheduler_ && !state_->retrieved) {
-                WaitImpl();
+                try {
+                    WaitImpl();
+                } catch (...) {
+                }
             }
             state_ = std::move(other.state_);
             scheduler_ = other.scheduler_;
@@ -68,12 +72,11 @@ public:
     }
 
     ~Future() {
-        // Destructor waits for fiber completion
         if (state_ && scheduler_ && !state_->retrieved) {
             try {
                 WaitImpl();
             } catch (...) {
-                // Suppress exceptions in destructor
+                // Suppress exceptions in destructor.
             }
         }
     }
@@ -105,7 +108,6 @@ public:
         WaitImpl();
         state_->retrieved = true;
 
-        // Check for exception (stored in state for safety after fiber cleanup)
         if (state_->exception) {
             std::rethrow_exception(state_->exception);
         }
@@ -129,12 +131,6 @@ public:
     }
 
 private:
-    template <typename U>
-    friend Future<U> Spawn(std::function<U()> func);
-
-    template <typename U>
-    friend Future<U> Spawn(std::function<U()> func, std::size_t stack_size);
-
     template <typename F>
     friend auto Spawn(F&& func) -> Future<std::invoke_result_t<F>>;
 
@@ -151,17 +147,14 @@ private:
 
         auto* fiber = scheduler_->GetFiber(state_->fiber_id);
         if (!fiber || fiber->IsDone()) {
-            // Fiber already done or cleaned up, exception already in state
             return;
         }
 
-        // Add current fiber as waiter
         auto* current = scheduler_->GetCurrentFiber();
         if (current) {
-            fiber->AddWaiter(current);
+            fiber->AddWaiter(current->GetId());
             scheduler_->SuspendCurrent();
         }
-        // Exception is stored in state by Spawn wrapper, no need to copy here
     }
 
     std::shared_ptr<detail::FutureState<T>> state_;
@@ -186,7 +179,10 @@ public:
     Future& operator=(Future&& other) noexcept {
         if (this != &other) {
             if (state_ && scheduler_ && !state_->retrieved) {
-                WaitImpl();
+                try {
+                    WaitImpl();
+                } catch (...) {
+                }
             }
             state_ = std::move(other.state_);
             scheduler_ = other.scheduler_;
@@ -200,7 +196,6 @@ public:
             try {
                 WaitImpl();
             } catch (...) {
-                // Suppress exceptions in destructor
             }
         }
     }
@@ -217,7 +212,6 @@ public:
         WaitImpl();
         state_->retrieved = true;
 
-        // Check for exception (stored in state for safety after fiber cleanup)
         if (state_->exception) {
             std::rethrow_exception(state_->exception);
         }
@@ -235,12 +229,6 @@ public:
     }
 
 private:
-    template <typename U>
-    friend Future<U> Spawn(std::function<U()> func);
-
-    template <typename U>
-    friend Future<U> Spawn(std::function<U()> func, std::size_t stack_size);
-
     template <typename F>
     friend auto Spawn(F&& func) -> Future<std::invoke_result_t<F>>;
 
@@ -257,16 +245,14 @@ private:
 
         auto* fiber = scheduler_->GetFiber(state_->fiber_id);
         if (!fiber || fiber->IsDone()) {
-            // Fiber already done or cleaned up, exception already in state
             return;
         }
 
         auto* current = scheduler_->GetCurrentFiber();
         if (current) {
-            fiber->AddWaiter(current);
+            fiber->AddWaiter(current->GetId());
             scheduler_->SuspendCurrent();
         }
-        // Exception is stored in state by Spawn wrapper, no need to copy here
     }
 
     std::shared_ptr<detail::FutureState<void>> state_;
@@ -275,6 +261,9 @@ private:
 
 /**
  * @brief Spawn a new fiber with custom stack size.
+ *
+ * The fiber's exception (if any) is captured in the shared state without
+ * propagating through the scheduler — the awaiter retrieves it via Get/Wait.
  *
  * @param func The function to execute in the fiber.
  * @param stack_size The stack size for the fiber.
@@ -288,31 +277,25 @@ auto Spawn(F&& func, std::size_t stack_size) -> Future<std::invoke_result_t<F>> 
     auto state = std::make_shared<detail::FutureState<ResultType>>();
 
     if constexpr (std::is_void_v<ResultType>) {
-        auto fiber_id = scheduler.SpawnFiberInternal(
+        state->fiber_id = scheduler.SpawnFiberInternal(
             [state, f = std::forward<F>(func)]() mutable {
                 try {
                     f();
                 } catch (...) {
-                    // Store exception in state immediately (fiber may be cleaned up later)
                     state->exception = std::current_exception();
-                    throw; // Re-throw so scheduler knows fiber failed
                 }
             },
             stack_size);
-        state->fiber_id = fiber_id;
     } else {
-        auto fiber_id = scheduler.SpawnFiberInternal(
+        state->fiber_id = scheduler.SpawnFiberInternal(
             [state, f = std::forward<F>(func)]() mutable {
                 try {
-                    state->result = f();
+                    state->result.emplace(f());
                 } catch (...) {
-                    // Store exception in state immediately (fiber may be cleaned up later)
                     state->exception = std::current_exception();
-                    throw;
                 }
             },
             stack_size);
-        state->fiber_id = fiber_id;
     }
 
     return Future<ResultType>(std::move(state), &scheduler);

--- a/include/cortex/tiny_fiber/mutex.hpp
+++ b/include/cortex/tiny_fiber/mutex.hpp
@@ -79,9 +79,12 @@ public:
 private:
     friend class ConditionVariable;
 
+    // Waiters are stored by ID rather than pointer so a fiber that died (or was
+    // force-scheduled by Scheduler::Stop()) while still listed here is detected
+    // and skipped on the next Unlock — avoiding use-after-free of a stale Fiber*.
     bool locked_ {false};
     detail::Fiber* owner_ {nullptr};
-    std::deque<detail::Fiber*> waiters_;
+    std::deque<detail::Fiber::Id> waiters_;
 };
 
 /**

--- a/include/cortex/tiny_fiber/scheduler.hpp
+++ b/include/cortex/tiny_fiber/scheduler.hpp
@@ -188,6 +188,8 @@ private:
     Config config_;
     bool running_ {false};
     bool stopping_ {false};
+    // Per-scheduler fiber ID counter; starts at 1 so 0 is a sentinel "no fiber".
+    detail::Fiber::Id next_fiber_id_ {1};
     detail::Fiber* current_fiber_ {nullptr};
     std::deque<detail::Fiber*> ready_queue_;
     std::unordered_map<detail::Fiber::Id, std::unique_ptr<detail::Fiber>> fibers_;

--- a/src/tiny_fiber/condition_variable.cpp
+++ b/src/tiny_fiber/condition_variable.cpp
@@ -2,22 +2,11 @@
 #include <cortex/tiny_fiber/errors/scheduler_stopping_error.hpp>
 #include <cortex/tiny_fiber/scheduler.hpp>
 
-#include <cassert>
 #include <stdexcept>
 
 namespace cortex::tiny_fiber {
 
-ConditionVariable::~ConditionVariable() {
-    // In debug mode, this indicates a programming error
-    // We handle it gracefully by clearing waiters
-#ifndef NDEBUG
-    if (!waiters_.empty()) {
-        // ConditionVariable destroyed with waiters - this is a bug but don't crash
-    }
-#endif
-    // Clear waiters to avoid dangling pointers
-    waiters_.clear();
-}
+ConditionVariable::~ConditionVariable() = default;
 
 void ConditionVariable::Wait(Mutex::Guard& guard) {
     if (!guard.mutex_) {
@@ -26,57 +15,57 @@ void ConditionVariable::Wait(Mutex::Guard& guard) {
 
     auto& scheduler = Scheduler::Current();
 
-    // Check for stopping
     if (scheduler.IsStopping()) {
         throw SchedulerStoppingError();
     }
 
     auto* current = scheduler.GetCurrentFiber();
-
     if (!current) {
         throw std::logic_error("ConditionVariable::Wait() must be called from within a fiber");
     }
 
-    // Add to wait queue
-    waiters_.push_back(current);
+    waiters_.push_back(current->GetId());
 
-    // Unlock mutex while waiting
-    guard.mutex_->Unlock();
+    // Detach the guard from the mutex before unlocking so that, if any subsequent
+    // step throws, the Guard destructor doesn't try to Unlock an unlocked mutex
+    // during stack unwinding (which would terminate via throw-in-destructor).
+    auto* mutex = guard.mutex_;
+    guard.mutex_ = nullptr;
+    mutex->Unlock();
 
-    // Suspend until notified
     scheduler.SuspendCurrent();
 
-    // Check for stopping after waking up
     if (scheduler.IsStopping()) {
-        // Don't try to re-lock, just propagate the stop signal
         throw SchedulerStoppingError();
     }
 
-    // Re-lock mutex after waking up
-    guard.mutex_->Lock();
+    mutex->Lock();
+    guard.mutex_ = mutex; // Re-attach: guard owns the mutex again.
 }
 
 void ConditionVariable::NotifyOne() {
-    if (waiters_.empty()) {
-        return;
-    }
-
     auto& scheduler = Scheduler::Current();
-    auto* waiter = waiters_.front();
-    waiters_.pop_front();
-    scheduler.Schedule(waiter);
+    // Skip stale entries (fibers that died or were force-scheduled).
+    while (!waiters_.empty()) {
+        auto id = waiters_.front();
+        waiters_.pop_front();
+        auto* waiter = scheduler.GetFiber(id);
+        if (waiter && waiter->IsSuspended()) {
+            scheduler.Schedule(waiter);
+            return;
+        }
+    }
 }
 
 void ConditionVariable::NotifyAll() {
-    if (waiters_.empty()) {
-        return;
-    }
-
     auto& scheduler = Scheduler::Current();
     while (!waiters_.empty()) {
-        auto* waiter = waiters_.front();
+        auto id = waiters_.front();
         waiters_.pop_front();
-        scheduler.Schedule(waiter);
+        auto* waiter = scheduler.GetFiber(id);
+        if (waiter && waiter->IsSuspended()) {
+            scheduler.Schedule(waiter);
+        }
     }
 }
 

--- a/src/tiny_fiber/fiber.cpp
+++ b/src/tiny_fiber/fiber.cpp
@@ -6,24 +6,14 @@
 
 namespace cortex::tiny_fiber::detail {
 
-std::unique_ptr<Fiber> Fiber::Make(Body body, std::size_t stack_size, MemoryResourceSharedPtr resource) {
-    static Id g_fiber_id = 1;
-    return std::make_unique<Fiber>(PrivateTag {}, g_fiber_id++, std::move(body), stack_size, std::move(resource));
-}
-
-Fiber::Fiber(PrivateTag, Id id, Body body, std::size_t stack_size, MemoryResourceSharedPtr resource)
+Fiber::Fiber(Id id, Body body, std::size_t stack_size, MemoryResourceSharedPtr resource)
     : BaseCoroutine(stack_size, std::move(resource))
     , id_(id)
     , body_(std::move(body)) {}
 
 void Fiber::Continuation(CoroutineSuspendContext& ctx) {
-    // Store suspend context so Yield/Park can use it
     suspend_ctx_ = &ctx;
-
-    // Execute the user's function
     body_();
-
-    // Clear context when done
     suspend_ctx_ = nullptr;
 }
 
@@ -50,7 +40,7 @@ void Fiber::Wake() {
     state_ = FiberState::Ready;
 }
 
-std::vector<Fiber*> Fiber::Complete() {
+std::vector<Fiber::Id> Fiber::Complete() {
     suspend_ctx_ = nullptr;
     state_ = FiberState::Finished;
     return std::move(waiters_);
@@ -63,9 +53,9 @@ void Fiber::Suspend() {
     suspend_ctx_->Suspend();
 }
 
-void Fiber::AddWaiter(Fiber* waiter) {
-    if (waiter) {
-        waiters_.push_back(waiter);
+void Fiber::AddWaiter(Id waiter_id) {
+    if (waiter_id != 0) {
+        waiters_.push_back(waiter_id);
     }
 }
 

--- a/src/tiny_fiber/mutex.cpp
+++ b/src/tiny_fiber/mutex.cpp
@@ -2,54 +2,35 @@
 #include <cortex/tiny_fiber/mutex.hpp>
 #include <cortex/tiny_fiber/scheduler.hpp>
 
-#include <cassert>
 #include <stdexcept>
 
 namespace cortex::tiny_fiber {
 
-Mutex::~Mutex() {
-    // In debug mode, warn if mutex is destroyed while locked or has waiters
-    // This indicates a programming error but we handle it gracefully
-#ifndef NDEBUG
-    if (locked_) {
-        // Mutex destroyed while locked - this is a bug but don't crash
-    }
-    if (!waiters_.empty()) {
-        // Mutex destroyed with waiters - this is a bug but don't crash
-    }
-#endif
-    waiters_.clear();
-    locked_ = false;
-    owner_ = nullptr;
-}
+Mutex::~Mutex() = default;
 
 void Mutex::Lock() {
     auto& scheduler = Scheduler::Current();
 
-    // Check for stopping first
     if (scheduler.IsStopping()) {
         throw SchedulerStoppingError();
     }
 
     auto* current = scheduler.GetCurrentFiber();
-
     if (!current) {
         throw std::logic_error("Mutex::Lock() must be called from within a fiber");
     }
 
-    // Check for recursive lock (same fiber trying to lock twice)
     if (locked_ && owner_ == current) {
         throw std::logic_error("Mutex::Lock() recursive lock detected");
     }
 
     while (locked_) {
-        // Check for stopping while waiting
         if (scheduler.IsStopping()) {
+            // We may have a stale entry in waiters_ from a previous iteration.
+            // Unlock() validates entries on pop, so we leave it for cleanup there.
             throw SchedulerStoppingError();
         }
-        // Add to wait queue
-        waiters_.push_back(current);
-        // Suspend until mutex is available
+        waiters_.push_back(current->GetId());
         scheduler.SuspendCurrent();
     }
 
@@ -78,8 +59,7 @@ void Mutex::Unlock() {
     auto& scheduler = Scheduler::Current();
     auto* current = scheduler.GetCurrentFiber();
 
-    // During scheduler destruction/forced unwinding, current may be nullptr
-    // In that case, skip the owner check as we're cleaning up
+    // During scheduler destruction current may be nullptr; skip the owner check.
     if (current != nullptr && owner_ != current) {
         throw std::logic_error("Mutex::Unlock() called by non-owner fiber");
     }
@@ -87,11 +67,20 @@ void Mutex::Unlock() {
     locked_ = false;
     owner_ = nullptr;
 
-    // Wake up one waiter if any (skip during cleanup when current is nullptr)
-    if (current != nullptr && !waiters_.empty()) {
-        auto* waiter = waiters_.front();
+    if (current == nullptr) {
+        return;
+    }
+
+    // Pop until we find a still-Suspended waiter. Entries can be stale if the
+    // fiber was force-scheduled by Stop() or has already completed.
+    while (!waiters_.empty()) {
+        auto id = waiters_.front();
         waiters_.pop_front();
-        scheduler.Schedule(waiter);
+        auto* waiter = scheduler.GetFiber(id);
+        if (waiter && waiter->IsSuspended()) {
+            scheduler.Schedule(waiter);
+            return;
+        }
     }
 }
 

--- a/src/tiny_fiber/scheduler.cpp
+++ b/src/tiny_fiber/scheduler.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <stdexcept>
+#include <utility>
 
 namespace cortex::tiny_fiber {
 
@@ -21,16 +22,15 @@ Scheduler::Scheduler(Config config)
     : config_(std::move(config)) {}
 
 Scheduler::~Scheduler() {
-    // Signal stop and let fibers exit gracefully
     if (!stopping_) {
         Stop();
     }
 
-    // Set ourselves as current scheduler during final cleanup
+    // Set ourselves as current scheduler during final cleanup so fibers can
+    // resolve Scheduler::Current() while unwinding.
     g_current_scheduler = this;
 
-    // Run remaining fibers to let them handle the stopping signal
-    // They should catch SchedulerStoppingError and exit
+    // Run remaining fibers so they catch SchedulerStoppingError and exit.
     while (!ready_queue_.empty()) {
         current_fiber_ = ready_queue_.front();
         ready_queue_.pop_front();
@@ -39,30 +39,29 @@ Scheduler::~Scheduler() {
             try {
                 current_fiber_->Run();
             } catch (...) {
-                // Ignore exceptions during shutdown
+                // Ignore exceptions during shutdown.
             }
         }
         current_fiber_ = nullptr;
     }
 
-    // Clear remaining state
     running_ = false;
-
-    // Explicitly clear fibers (triggers forced unwinding for any that didn't exit)
+    // Clearing fibers_ triggers forced unwinding for any that didn't exit.
     fibers_.clear();
-
-    // Now clear the global scheduler pointer
     g_current_scheduler = nullptr;
 }
 
 void Scheduler::Stop() {
     if (stopping_) {
-        return; // Already stopping
+        return;
     }
 
     stopping_ = true;
 
-    // Wake up all suspended fibers so they can exit gracefully
+    // Wake every suspended fiber so it can observe IsStopping() and exit. Each
+    // fiber may still be referenced by stale entries in someone's waiter queue;
+    // unlock/notify code paths skip stale entries, and Step() validates waiter
+    // IDs on Complete(), so this is safe.
     for (auto& [id, fiber] : fibers_) {
         if (fiber && fiber->IsSuspended()) {
             Schedule(fiber.get());
@@ -78,7 +77,6 @@ void Scheduler::ProcessPendingCleanup() {
 }
 
 bool Scheduler::Step() {
-    // Clean up finished fibers from previous iteration
     ProcessPendingCleanup();
 
     if (ready_queue_.empty()) {
@@ -100,24 +98,27 @@ bool Scheduler::Step() {
     try {
         current_fiber_->Run();
     } catch (...) {
-        current_fiber_->SetException(std::current_exception());
+        // The entry fiber (created via Run() rather than Spawn()) has no
+        // future to deliver the exception to. Swallow during cooperative
+        // execution rather than tearing down the scheduler.
     }
 
     if (current_fiber_->IsDone()) {
-        auto waiters = current_fiber_->Complete();
-        for (auto* waiter : waiters) {
+        // Complete() returns waiter IDs; resolve each via the fiber map and
+        // skip any that are gone or already runnable.
+        auto waiter_ids = current_fiber_->Complete();
+        for (auto id : waiter_ids) {
+            auto* waiter = GetFiber(id);
             if (waiter && waiter->IsSuspended()) {
                 Schedule(waiter);
             }
         }
 
-        // Schedule fiber for cleanup (will be deleted at start of next iteration)
         pending_cleanup_.push_back(current_fiber_->GetId());
     }
 
     current_fiber_ = nullptr;
 
-    // Return true if there's more work
     bool has_more = !ready_queue_.empty();
     if (!has_more) {
         running_ = false;
@@ -133,18 +134,15 @@ void Scheduler::RunLoop() {
     while (Step()) {
     }
 
-    // Clean up the last completed fiber(s)
     ProcessPendingCleanup();
 }
 
 detail::Fiber::Id Scheduler::SpawnFiberInternal(detail::Fiber::Body func, std::size_t stack_size) {
-    auto fiber = detail::Fiber::Make(std::move(func), stack_size, config_.memory_resource);
-    const auto id = fiber->GetId();
+    const auto id = next_fiber_id_++;
+    auto fiber = std::make_unique<detail::Fiber>(id, std::move(func), stack_size, config_.memory_resource);
     auto* fiber_raw_ptr = fiber.get();
 
-    fibers_[id] = std::move(fiber);
-
-    // New fibers start in Ready state, just enqueue
+    fibers_.emplace(id, std::move(fiber));
     ready_queue_.push_back(fiber_raw_ptr);
 
     return id;
@@ -178,7 +176,6 @@ void Scheduler::YieldCurrent() {
         throw std::logic_error("No fiber is currently running");
     }
 
-    // Enqueue first, then yield (Yield sets Ready + suspends)
     ready_queue_.push_back(current_fiber_);
     current_fiber_->Yield();
 }

--- a/tests/tiny_fiber_test.cpp
+++ b/tests/tiny_fiber_test.cpp
@@ -1409,6 +1409,86 @@ TEST(TinyFiberStoppingTest, CondVarWaitThrowsWhenAlreadyStopping) {
     EXPECT_TRUE(caught);
 }
 
+// Regression: a fiber suspended inside CV::Wait must unwind cleanly when the
+// scheduler stops. The pre-fix path threw SchedulerStoppingError after
+// unlocking the guard's mutex but without detaching the guard, so ~Guard
+// called Unlock() on an unlocked mutex during unwind → terminate.
+TEST(TinyFiberStoppingTest, CondVarWaitInterruptedByStopUnwindsCleanly) {
+    bool caught = false;
+    {
+        auto scheduler = tf::Scheduler::Create([&caught] {
+            tf::Mutex mutex;
+            tf::ConditionVariable cv;
+            try {
+                auto guard = tf::Lock(mutex);
+                cv.Wait(guard);
+            } catch (const tf::SchedulerStoppingError&) {
+                caught = true;
+            }
+        });
+
+        scheduler->Step(); // Fiber locks mutex, suspends inside cv.Wait()
+        scheduler->Stop(); // Wakes the fiber while it's parked
+
+        while (!scheduler->IsDone()) {
+            scheduler->Step();
+        }
+    }
+    EXPECT_TRUE(caught);
+}
+
+// Regression: multiple fibers parked in Mutex::waiters_ must be safely cleaned
+// up after Stop(). The pre-fix path stored raw Fiber* in waiters_ and Unlock
+// dereferenced entries without validating state, so a force-scheduled fiber
+// (whose state had transitioned Suspended -> Ready via Stop) would hit
+// Schedule()->Wake()'s assert(state == Suspended) and, in release, end up in
+// ready_queue_ twice — leading to use-after-free once it was cleaned up.
+TEST(TinyFiberStoppingTest, MutexWaitersSurviveStop) {
+    bool holder_caught = false;
+    {
+        auto scheduler = tf::Scheduler::Create([&] {
+            tf::Mutex mutex;
+
+            auto holder = tf::Spawn([&] {
+                try {
+                    auto guard = tf::Lock(mutex);
+                    while (true)
+                        tf::Yield();
+                } catch (const tf::SchedulerStoppingError&) {
+                    holder_caught = true;
+                }
+            });
+
+            auto waiter1 = tf::Spawn([&] {
+                auto guard = tf::Lock(mutex);
+            });
+
+            auto waiter2 = tf::Spawn([&] {
+                auto guard = tf::Lock(mutex);
+            });
+
+            // Let everyone get into position: holder acquires the mutex,
+            // waiter1 and waiter2 park in mutex.waiters_.
+            tf::Yield();
+            tf::Yield();
+            tf::Yield();
+        });
+
+        for (int i = 0; i < 8 && !scheduler->IsDone(); ++i) {
+            scheduler->Step();
+        }
+        scheduler->Stop();
+        while (!scheduler->IsDone()) {
+            scheduler->Step();
+        }
+    }
+    // The point of this test is that shutdown completes cleanly. The holder
+    // unwinds on the stopping signal and releases the mutex; the woken waiters
+    // either catch stopping or acquire-and-release cleanly. The pre-fix code
+    // would either fire an assertion or trip use-after-free here.
+    EXPECT_TRUE(holder_caught);
+}
+
 // ============================================================================
 // Complex Scenarios - Additional Tests
 // ============================================================================


### PR DESCRIPTION
Three correctness issues in cortex::tiny_fiber could terminate the process or trip use-after-free during scheduler shutdown:

1. Mutex/CondVar/Fiber waiter lists stored raw Fiber* pointers. When Scheduler::Stop() force-scheduled a suspended fiber, it didn't pop the fiber from these waiter queues, so stale entries dangled once the fiber was cleaned up. The next Unlock/Notify/Complete then dereferenced freed memory (or hit Schedule()->Wake()'s assertion that state == Suspended). Switched waiter lists to store Fiber::Id, validated via Scheduler::GetFiber() on pop.

2. ConditionVariable::Wait unlocked the guard's mutex, suspended, then threw SchedulerStoppingError without re-locking. The Guard still held the Mutex* pointer, so ~Guard called Unlock() on an unlocked mutex during unwind — throwing inside a destructor while another exception was in flight terminates the process. Fixed by detaching the Guard before unlocking and re-attaching only on successful re-lock.

3. Future::operator= was noexcept but called a throwing WaitImpl. Wrapped the call in try/catch so the contract holds.

Also clean up:
- Replace the function-static fiber ID counter with a per-scheduler counter (no implicit global state across scheduler instances).
- Remove the redundant throw/rethrow in Spawn() wrapper; the exception is captured in the FutureState and Get/Wait surfaces it.
- Use Coroutine::kDefaultStackSizeBytes instead of the magic 262144 in BaseCoroutine, Generator, and the Builders.
- Drop the dead std::function-based Spawn friend declarations and unused Fiber::HasException/GetException/SetException.
- Strip dead default member initializers shadowed by Builder ctors.

Regression tests added for the two most critical scenarios (CondVar wait interrupted by Stop, Mutex waiters present at Stop). All 103 tests pass under both default and ASan/UBSan builds.