### PR TITLE
Add browser video editor demo (apps/video_editor)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -50,13 +50,23 @@ jobs:
       - name: Build AlgoViz (Optimized)
         run: cmake --build build/wasm-algoviz --config Release --target algo_viz
 
+      - name: Configure CMake for Video Editor (Release)
+        run: |
+          emcmake cmake -B build/wasm-video-editor -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCORTEX_BUILD_APPS=ON
+
+      - name: Build Video Editor (Optimized)
+        run: cmake --build build/wasm-video-editor --config Release --target video_editor
+
       - name: Generate Doxygen Docs
         run: doxygen Doxyfile
-      
+
       - name: Prepare deployment directory
         run: |
           mkdir -p deploy/examples
           mkdir -p deploy/algoviz
+          mkdir -p deploy/video-editor
           mkdir -p deploy/docs
 
           # Copy examples and all generated runtime artifacts
@@ -64,6 +74,9 @@ jobs:
 
           # Copy the built AlgoViz app bundle (static web + compiled runtime)
           cp -R build/wasm-algoviz/apps/algo_viz/. deploy/algoviz/
+
+          # Copy the built Video Editor bundle
+          cp -R build/wasm-video-editor/apps/video_editor/. deploy/video-editor/
 
           # Copy docs
           cp -R doc/html/. deploy/docs/
@@ -80,7 +93,16 @@ jobs:
           test -f deploy/algoviz/algoviz_bst.wasm
           test -f deploy/algoviz/algoviz_union_find.js
           test -f deploy/algoviz/algoviz_union_find.wasm
-          
+
+          # Fail fast if required Video Editor assets are missing
+          test -f deploy/video-editor/index.html
+          test -f deploy/video-editor/src/main.js
+          test -f deploy/video-editor/src/editor_app.js
+          test -f deploy/video-editor/src/editor_client.js
+          test -f deploy/video-editor/styles/main.css
+          test -f deploy/video-editor/video_editor.js
+          test -f deploy/video-editor/video_editor.wasm
+
           # Create a root index.html that links to everything
           cat > deploy/index.html << 'EOF'
           <!DOCTYPE html>
@@ -93,6 +115,7 @@ jobs:
           <body>
               <p>Redirecting to <a href="examples/examples_index.html">Cortex Examples</a>...</p>
               <p><a href="algoviz/index.html">AlgoViz - Visualization Catalog</a></p>
+              <p><a href="video-editor/index.html">Cortex Video Editor</a></p>
           </body>
           </html>
           EOF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(Dependencies)
 include(CompilerConfig)
 include(WasmConfig)
+include(AppRuntime)
 
 # --- Subdirectories ---
 add_subdirectory(src)
@@ -32,6 +33,11 @@ if(CORTEX_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if(CORTEX_BUILD_APPS)
+# Add apps/ when explicitly requested OR when building tests — some apps
+# (currently apps/video_editor) ship a native engine library that has its own
+# unit tests, and we want those tests to be part of the regular `ctest` run.
+# Each app's CMakeLists is responsible for gating its WASM-only bits behind
+# `if(EMSCRIPTEN)`.
+if(CORTEX_BUILD_APPS OR CORTEX_BUILD_TESTS)
     add_subdirectory(apps)
 endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(algo_viz)
+add_subdirectory(video_editor)

--- a/apps/algo_viz/CMakeLists.txt
+++ b/apps/algo_viz/CMakeLists.txt
@@ -5,51 +5,10 @@ endif()
 
 message(STATUS "AlgoViz: Configuring visualizers")
 
-# --- Optimization flags based on build type ---
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(ALGOVIZ_OPT_FLAGS "-Os")
-    set(ALGOVIZ_ASSERT_FLAG "-sASSERTIONS=0")
-else()
-    set(ALGOVIZ_OPT_FLAGS "-O0")
-    set(ALGOVIZ_ASSERT_FLAG "-sASSERTIONS=1")
-endif()
+# Build flags are shared across apps; cortex_add_wasm_app_runtime lives in
+# cmake/AppRuntime.cmake (included from the root CMakeLists).
 
-set(ALGOVIZ_COMMON_LINK_FLAGS
-    "-sALLOW_MEMORY_GROWTH=1"
-    "-sEXIT_RUNTIME=0"
-    "-sASYNCIFY_STACK_SIZE=65536"
-    "-sENVIRONMENT=web"
-    "-sINCOMING_MODULE_JS_API=['locateFile','onAbort','onRuntimeInitialized']"
-    "-sEXPORTED_RUNTIME_METHODS=['UTF8ToString']"
-    "${ALGOVIZ_ASSERT_FLAG}"
-    "${ALGOVIZ_OPT_FLAGS}"
-)
-
-function(cortex_add_algoviz_runtime TARGET_NAME OUTPUT_NAME EXPORTED_FUNCTIONS)
-    add_executable(${TARGET_NAME} engine/main.cpp)
-
-    target_include_directories(${TARGET_NAME} PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/engine
-    )
-
-    target_link_libraries(${TARGET_NAME} PRIVATE cortex::cortex)
-
-    set_target_properties(${TARGET_NAME} PROPERTIES
-        SUFFIX ".js"
-        OUTPUT_NAME "${OUTPUT_NAME}"
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-    )
-
-    target_link_options(${TARGET_NAME} PRIVATE
-        "-sEXPORTED_FUNCTIONS=${EXPORTED_FUNCTIONS}"
-        ${ALGOVIZ_COMMON_LINK_FLAGS}
-    )
-
-    cortex_apply_warnings(${TARGET_NAME})
-    cortex_apply_sanitizers(${TARGET_NAME})
-endfunction()
-
-cortex_add_algoviz_runtime(
+cortex_add_wasm_app_runtime(
     algoviz_bst
     "algoviz_bst"
     "[\
@@ -69,9 +28,12 @@ cortex_add_algoviz_runtime(
 '_get_node_right',\
 '_get_node_parent'\
 ]"
+    engine/main.cpp
 )
+target_include_directories(algoviz_bst PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/engine)
+target_link_libraries(algoviz_bst PRIVATE cortex::cortex)
 
-cortex_add_algoviz_runtime(
+cortex_add_wasm_app_runtime(
     algoviz_union_find
     "algoviz_union_find"
     "[\
@@ -86,7 +48,10 @@ cortex_add_algoviz_runtime(
 '_uf_union',\
 '_uf_connected'\
 ]"
+    engine/main.cpp
 )
+target_include_directories(algoviz_union_find PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/engine)
+target_link_libraries(algoviz_union_find PRIVATE cortex::cortex)
 
 add_custom_target(algo_viz_assets
     COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/apps/video_editor/CMakeLists.txt
+++ b/apps/video_editor/CMakeLists.txt
@@ -1,0 +1,88 @@
+message(STATUS "VideoEditor: Configuring engine library")
+
+# --- Engine static library (built both natively and under Emscripten) ---
+add_library(video_editor_engine STATIC
+    engine/src/frame_buffer.cpp
+    engine/src/procedural_source.cpp
+    engine/src/filters/brightness.cpp
+    engine/src/filters/contrast.cpp
+    engine/src/filters/saturation.cpp
+    engine/src/filters/gaussian_blur.cpp
+    engine/src/filter_chain.cpp
+    engine/src/pipeline.cpp
+    engine/src/blocking_runner.cpp
+    engine/src/cooperative_runner.cpp
+    engine/src/editor.cpp
+)
+
+target_include_directories(video_editor_engine PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/engine/include
+)
+
+target_link_libraries(video_editor_engine PUBLIC cortex::cortex)
+
+cortex_apply_warnings(video_editor_engine)
+cortex_apply_sanitizers(video_editor_engine)
+
+# --- WASM executable + web assets (Emscripten only) ---
+if(EMSCRIPTEN)
+    message(STATUS "VideoEditor: Configuring WASM bridge + web bundle")
+
+    cortex_add_wasm_app_runtime(
+        video_editor_runtime
+        "video_editor"
+        "[\
+'_main',\
+'_editor_init',\
+'_editor_shutdown',\
+'_editor_get_width',\
+'_editor_get_height',\
+'_editor_get_frame_count',\
+'_editor_get_source_frame',\
+'_editor_get_output_frame',\
+'_editor_set_brightness',\
+'_editor_set_contrast',\
+'_editor_set_saturation',\
+'_editor_set_blur_radius',\
+'_editor_render_preview',\
+'_editor_start_apply_cooperative',\
+'_editor_apply_blocking',\
+'_editor_step',\
+'_editor_get_progress',\
+'_editor_cancel'\
+]"
+        engine/bridge/wasm_bridge.cpp
+    )
+    target_link_libraries(video_editor_runtime PRIVATE video_editor_engine)
+
+    add_custom_target(video_editor_assets
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${CMAKE_CURRENT_SOURCE_DIR}/web
+                ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "VideoEditor: Copying web app to build directory"
+    )
+    add_dependencies(video_editor_assets video_editor_runtime)
+
+    add_custom_target(video_editor DEPENDS video_editor_runtime video_editor_assets)
+endif()
+
+# --- Native unit tests ---
+if(CORTEX_BUILD_TESTS AND NOT EMSCRIPTEN)
+    message(STATUS "VideoEditor: Configuring native engine tests")
+
+    add_executable(video_editor_engine_test
+        engine/tests/filters_test.cpp
+        engine/tests/filter_chain_test.cpp
+        engine/tests/pipeline_test.cpp
+        engine/tests/runners_test.cpp
+    )
+    target_link_libraries(video_editor_engine_test PRIVATE
+        video_editor_engine
+        GTest::gtest_main
+    )
+    cortex_apply_warnings(video_editor_engine_test)
+    cortex_apply_sanitizers(video_editor_engine_test)
+
+    include(GoogleTest)
+    gtest_discover_tests(video_editor_engine_test)
+endif()

--- a/apps/video_editor/engine/bridge/wasm_bridge.cpp
+++ b/apps/video_editor/engine/bridge/wasm_bridge.cpp
@@ -1,0 +1,141 @@
+// WebAssembly bridge for the video_editor demo.
+//
+// Pure translation: forwards extern "C" calls into the Editor facade and
+// implements IProgressListener by relaying events into JS via EM_JS. No
+// editor logic lives here.
+
+#include <video_editor/editor.hpp>
+#include <video_editor/progress_listener.hpp>
+
+#include <cortex/config.hpp>
+
+#include <cstdint>
+#include <memory>
+
+#ifdef CORTEX_EMSCRIPTEN
+#include <emscripten/emscripten.h>
+#endif
+
+namespace {
+
+using cortex::video_editor::Editor;
+using cortex::video_editor::FrameBuffer;
+using cortex::video_editor::IProgressListener;
+
+std::unique_ptr<Editor> g_editor;
+
+#ifdef CORTEX_EMSCRIPTEN
+// clang-format off
+EM_JS(void, js_on_progress, (float pct), {
+    if (typeof onApplyProgress === 'function') {
+        onApplyProgress(pct);
+    }
+});
+EM_JS(void, js_on_complete, (), {
+    if (typeof onApplyComplete === 'function') {
+        onApplyComplete();
+    }
+});
+EM_JS(void, js_on_cancelled, (), {
+    if (typeof onApplyCancelled === 'function') {
+        onApplyCancelled();
+    }
+});
+// clang-format on
+#else
+// Stubs so the bridge compiles natively (unused; the WASM build is the real target).
+inline void js_on_progress(float) {}
+inline void js_on_complete() {}
+inline void js_on_cancelled() {}
+#endif
+
+class JsProgressListener final : public IProgressListener {
+public:
+    void OnProgress(float pct) override {
+        js_on_progress(pct);
+    }
+    void OnComplete() override {
+        js_on_complete();
+    }
+    void OnCancelled() override {
+        js_on_cancelled();
+    }
+};
+
+JsProgressListener g_listener;
+
+} // namespace
+
+extern "C" {
+
+CORTEX_API int editor_init(int width, int height, int frame_count) {
+    g_editor = Editor::Create(width, height, frame_count);
+    return g_editor ? 1 : 0;
+}
+
+CORTEX_API void editor_shutdown() {
+    g_editor.reset();
+}
+
+CORTEX_API int editor_get_width() {
+    return g_editor ? g_editor->Width() : 0;
+}
+
+CORTEX_API int editor_get_height() {
+    return g_editor ? g_editor->Height() : 0;
+}
+
+CORTEX_API int editor_get_frame_count() {
+    return g_editor ? g_editor->FrameCount() : 0;
+}
+
+CORTEX_API const std::uint8_t* editor_get_source_frame(int idx) {
+    return g_editor ? g_editor->Source(idx).Data() : nullptr;
+}
+
+CORTEX_API const std::uint8_t* editor_get_output_frame(int idx) {
+    return g_editor ? g_editor->Output(idx).Data() : nullptr;
+}
+
+CORTEX_API void editor_set_brightness(float v) {
+    if (g_editor) g_editor->SetBrightness(v);
+}
+
+CORTEX_API void editor_set_contrast(float v) {
+    if (g_editor) g_editor->SetContrast(v);
+}
+
+CORTEX_API void editor_set_saturation(float v) {
+    if (g_editor) g_editor->SetSaturation(v);
+}
+
+CORTEX_API void editor_set_blur_radius(int r) {
+    if (g_editor) g_editor->SetBlurRadius(r);
+}
+
+CORTEX_API void editor_render_preview(int idx) {
+    if (g_editor) g_editor->RenderPreview(idx);
+}
+
+CORTEX_API void editor_start_apply_cooperative() {
+    if (g_editor) g_editor->StartCooperativeApply(g_listener);
+}
+
+CORTEX_API void editor_apply_blocking() {
+    if (g_editor) g_editor->RunBlockingApply(g_listener);
+}
+
+CORTEX_API int editor_step() {
+    if (!g_editor) return 0;
+    return g_editor->Step() ? 1 : 0;
+}
+
+CORTEX_API float editor_get_progress() {
+    return g_editor ? g_editor->Progress() : 1.0f;
+}
+
+CORTEX_API void editor_cancel() {
+    if (g_editor) g_editor->Cancel();
+}
+
+} // extern "C"

--- a/apps/video_editor/engine/bridge/wasm_bridge.cpp
+++ b/apps/video_editor/engine/bridge/wasm_bridge.cpp
@@ -139,3 +139,11 @@ CORTEX_API void editor_cancel() {
 }
 
 } // extern "C"
+
+// Emscripten expects an entry point even though all editor lifecycle is
+// driven by JS calls into the exported functions above. Return 0 so the
+// runtime treats startup as successful; -sEXIT_RUNTIME=0 keeps the module
+// alive afterwards.
+int main() {
+    return 0;
+}

--- a/apps/video_editor/engine/include/video_editor/blocking_runner.hpp
+++ b/apps/video_editor/engine/include/video_editor/blocking_runner.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <video_editor/progress_listener.hpp>
+#include <video_editor/runner.hpp>
+
+namespace cortex::video_editor {
+
+class Pipeline;
+
+// Sequential runner — no cooperation, no fibers. Runs the entire apply-all
+// loop in a single synchronous call to Start(). The JS event loop never gets
+// a chance during this time, so the UI freezes. This is the negative-case
+// foil for the cooperative demo.
+class BlockingRunner final : public IRunner {
+public:
+    void Start(Pipeline& pipeline, IProgressListener& listener) override;
+    bool Step() override; // no-op for blocking runner; returns false
+    void Cancel() override;
+
+    [[nodiscard]] bool IsRunning() const noexcept override {
+        return false;
+    }
+    [[nodiscard]] float Progress() const noexcept override {
+        return progress_;
+    }
+
+private:
+    float progress_ {0.0f};
+    bool cancel_requested_ {false};
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/cooperative_runner.hpp
+++ b/apps/video_editor/engine/include/video_editor/cooperative_runner.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <video_editor/progress_listener.hpp>
+#include <video_editor/runner.hpp>
+
+#include <cortex/tiny_fiber/scheduler.hpp>
+
+#include <atomic>
+#include <memory>
+
+namespace cortex::video_editor {
+
+class Pipeline;
+
+// Cooperative runner backed by tiny_fiber. Spawns N worker fibers; each owns
+// a slice of the frame index range and calls tf::Yield() after every frame so
+// JS gets a turn between work units. The runner is driven by repeated Step()
+// calls from JS (typically once per requestAnimationFrame).
+//
+// On Cancel(): scheduler->Stop() signals all suspended fibers. They observe
+// IsStopping() at the next yield and throw SchedulerStoppingError, which the
+// worker bodies catch and let propagate. The next Step() drains the
+// remaining fibers and dispatches OnCancelled() on the listener.
+class CooperativeRunner final : public IRunner {
+public:
+    // workers — number of parallel fibers. 1 means strictly serial-with-yields;
+    // 3–4 is a good default. Workers > FrameCount() is silently clamped.
+    explicit CooperativeRunner(int workers = 3);
+    ~CooperativeRunner() override;
+
+    void Start(Pipeline& pipeline, IProgressListener& listener) override;
+    bool Step() override;
+    void Cancel() override;
+
+    [[nodiscard]] bool IsRunning() const noexcept override {
+        return scheduler_ != nullptr && !finished_;
+    }
+    [[nodiscard]] float Progress() const noexcept override;
+
+private:
+    void DispatchCompletionIfDone();
+
+    int worker_count_;
+    std::unique_ptr<tiny_fiber::Scheduler> scheduler_;
+
+    // Shared state read by workers; pipeline_ and listener_ are caller-owned.
+    Pipeline* pipeline_ {nullptr};
+    IProgressListener* listener_ {nullptr};
+
+    // Frame index counter shared across workers — atomic in shape only; in
+    // single-threaded cooperative scheduling there's no real contention, but
+    // using atomic<int> makes the model explicit and lets future native multi-
+    // thread experiments share the code.
+    std::atomic<int> next_frame_ {0};
+    std::atomic<int> completed_frames_ {0};
+
+    int total_frames_ {0};
+    bool finished_ {false};
+    bool cancelled_ {false};
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/editor.hpp
+++ b/apps/video_editor/engine/include/video_editor/editor.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <video_editor/frame_buffer.hpp>
+#include <video_editor/progress_listener.hpp>
+
+#include <memory>
+
+namespace cortex::video_editor {
+
+// Facade for the entire video-editor engine. The WASM bridge interacts only
+// with this class; concrete pipeline / runner / filter types stay
+// implementation-private behind a PIMPL.
+class Editor final {
+public:
+    static std::unique_ptr<Editor> Create(int width, int height, int frame_count);
+    ~Editor();
+
+    Editor(const Editor&) = delete;
+    Editor& operator=(const Editor&) = delete;
+    Editor(Editor&&) = delete;
+    Editor& operator=(Editor&&) = delete;
+
+    [[nodiscard]] int Width() const noexcept;
+    [[nodiscard]] int Height() const noexcept;
+    [[nodiscard]] int FrameCount() const noexcept;
+
+    [[nodiscard]] const FrameBuffer& Source(int idx) const;
+    [[nodiscard]] const FrameBuffer& Output(int idx) const;
+
+    // Filter parameters. Setters do not re-render; call RenderPreview() to
+    // see the result on the currently-selected frame.
+    void SetBrightness(float v); // -1.0 .. 1.0
+    void SetContrast(float v); //  0.0 .. 2.0
+    void SetSaturation(float v); //  0.0 .. 2.0
+    void SetBlurRadius(int r); //  0 .. 32
+
+    // Run the current filter chain on a single source frame and write to the
+    // matching output buffer. Used by the live-preview path.
+    void RenderPreview(int frame_idx);
+
+    // Bulk apply across all frames. Cooperative uses tiny_fiber and yields to
+    // JS between frames; blocking runs to completion synchronously.
+    void StartCooperativeApply(IProgressListener& listener);
+    void RunBlockingApply(IProgressListener& listener);
+
+    // Advance the cooperative runner one Step. Returns true if more work is
+    // pending. No-op when no run is in progress.
+    bool Step();
+
+    // Signal the cooperative runner to stop; runners exit at the next yield.
+    void Cancel();
+
+    [[nodiscard]] float Progress() const noexcept;
+
+private:
+    class Impl;
+    explicit Editor(std::unique_ptr<Impl> impl) noexcept;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/filter.hpp
+++ b/apps/video_editor/engine/include/video_editor/filter.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <video_editor/frame_buffer.hpp>
+
+namespace cortex::video_editor {
+
+// Strategy interface for a single image-processing operation. Implementations
+// read `in` and write `out`. Both buffers have identical dimensions, sized
+// before Apply() is called.
+class IFilter {
+public:
+    virtual ~IFilter() = default;
+
+    virtual void Apply(const FrameBuffer& in, FrameBuffer& out) const = 0;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/filter_chain.hpp
+++ b/apps/video_editor/engine/include/video_editor/filter_chain.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <video_editor/filter.hpp>
+#include <video_editor/frame_buffer.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace cortex::video_editor {
+
+// Composes a sequence of filters and applies them in order. Empty chain is a
+// pure copy. For chains with >= 2 filters the chain pings between an internal
+// scratch buffer and the caller-supplied output buffer to avoid extra
+// allocations per Apply() call.
+class FilterChain final {
+public:
+    FilterChain() = default;
+
+    FilterChain(const FilterChain&) = delete;
+    FilterChain& operator=(const FilterChain&) = delete;
+    FilterChain(FilterChain&&) noexcept = default;
+    FilterChain& operator=(FilterChain&&) noexcept = default;
+
+    void Add(std::unique_ptr<IFilter> filter);
+    void Clear() noexcept;
+
+    [[nodiscard]] std::size_t Size() const noexcept {
+        return filters_.size();
+    }
+
+    [[nodiscard]] bool Empty() const noexcept {
+        return filters_.empty();
+    }
+
+    // Reads `in`, writes the final result to `out`. May use an internal
+    // scratch buffer sized to match in/out dimensions.
+    void Apply(const FrameBuffer& in, FrameBuffer& out) const;
+
+private:
+    std::vector<std::unique_ptr<IFilter>> filters_;
+    mutable FrameBuffer scratch_;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/filters/brightness.hpp
+++ b/apps/video_editor/engine/include/video_editor/filters/brightness.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <video_editor/filter.hpp>
+
+namespace cortex::video_editor::filters {
+
+// Per-pixel linear brightness shift. `delta` in [-1.0, 1.0] is added to each
+// channel (after scaling to [0,1]); 0.0 is identity.
+class BrightnessFilter final : public IFilter {
+public:
+    explicit BrightnessFilter(float delta) noexcept;
+
+    void Apply(const FrameBuffer& in, FrameBuffer& out) const override;
+
+private:
+    float delta_;
+};
+
+} // namespace cortex::video_editor::filters

--- a/apps/video_editor/engine/include/video_editor/filters/contrast.hpp
+++ b/apps/video_editor/engine/include/video_editor/filters/contrast.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <video_editor/filter.hpp>
+
+namespace cortex::video_editor::filters {
+
+// Per-pixel contrast adjustment around mid-gray (128). `gain` in [0.0, 2.0];
+// 1.0 is identity, 0.0 flattens to mid-gray, 2.0 doubles contrast.
+class ContrastFilter final : public IFilter {
+public:
+    explicit ContrastFilter(float gain) noexcept;
+
+    void Apply(const FrameBuffer& in, FrameBuffer& out) const override;
+
+private:
+    float gain_;
+};
+
+} // namespace cortex::video_editor::filters

--- a/apps/video_editor/engine/include/video_editor/filters/gaussian_blur.hpp
+++ b/apps/video_editor/engine/include/video_editor/filters/gaussian_blur.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <video_editor/filter.hpp>
+
+#include <vector>
+
+namespace cortex::video_editor::filters {
+
+// Separable Gaussian blur. `radius` in pixels: 0 is identity, larger values
+// are progressively heavier. Kernel sigma derives from radius (sigma = max(0.5,
+// radius/2)) and the kernel is computed once in the constructor.
+//
+// Apply() does two passes through a scratch buffer (horizontal then vertical).
+// The scratch buffer is held as a mutable member so chained Apply() calls
+// don't reallocate; this is the heavy filter that the demo showcases.
+class GaussianBlurFilter final : public IFilter {
+public:
+    explicit GaussianBlurFilter(int radius);
+
+    void Apply(const FrameBuffer& in, FrameBuffer& out) const override;
+
+private:
+    int radius_;
+    std::vector<float> kernel_;
+    mutable FrameBuffer scratch_;
+};
+
+} // namespace cortex::video_editor::filters

--- a/apps/video_editor/engine/include/video_editor/filters/saturation.hpp
+++ b/apps/video_editor/engine/include/video_editor/filters/saturation.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <video_editor/filter.hpp>
+
+namespace cortex::video_editor::filters {
+
+// Saturation adjustment around luma. `scale` in [0.0, 2.0]; 1.0 is identity,
+// 0.0 produces grayscale, 2.0 oversaturates. Operates on each pixel via the
+// formula:  out = luma + (in - luma) * scale, where luma = 0.299R + 0.587G + 0.114B.
+class SaturationFilter final : public IFilter {
+public:
+    explicit SaturationFilter(float scale) noexcept;
+
+    void Apply(const FrameBuffer& in, FrameBuffer& out) const override;
+
+private:
+    float scale_;
+};
+
+} // namespace cortex::video_editor::filters

--- a/apps/video_editor/engine/include/video_editor/frame_buffer.hpp
+++ b/apps/video_editor/engine/include/video_editor/frame_buffer.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace cortex::video_editor {
+
+// Owns an RGBA8 pixel buffer of fixed width × height. Stride is implicit
+// (width * 4). All filters consume and produce FrameBuffers of identical
+// dimensions; no resizing is performed inside the editor.
+class FrameBuffer final {
+public:
+    FrameBuffer() = default;
+    FrameBuffer(int width, int height);
+
+    FrameBuffer(const FrameBuffer&) = default;
+    FrameBuffer(FrameBuffer&&) noexcept = default;
+    FrameBuffer& operator=(const FrameBuffer&) = default;
+    FrameBuffer& operator=(FrameBuffer&&) noexcept = default;
+
+    [[nodiscard]] int Width() const noexcept {
+        return width_;
+    }
+
+    [[nodiscard]] int Height() const noexcept {
+        return height_;
+    }
+
+    [[nodiscard]] std::size_t SizeBytes() const noexcept {
+        return pixels_.size();
+    }
+
+    [[nodiscard]] std::uint8_t* Data() noexcept {
+        return pixels_.data();
+    }
+
+    [[nodiscard]] const std::uint8_t* Data() const noexcept {
+        return pixels_.data();
+    }
+
+    // Copies pixel data from another buffer with identical dimensions.
+    void CopyFrom(const FrameBuffer& other);
+
+    // Fills the buffer with a solid RGBA color (used by tests).
+    void Fill(std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a);
+
+private:
+    int width_ {0};
+    int height_ {0};
+    std::vector<std::uint8_t> pixels_;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/frame_source.hpp
+++ b/apps/video_editor/engine/include/video_editor/frame_source.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <video_editor/frame_buffer.hpp>
+
+namespace cortex::video_editor {
+
+// Strategy interface for "where do frames come from?". The procedural source
+// is the only implementation today; a real-video source would slot in here
+// without touching anything else.
+class IFrameSource {
+public:
+    virtual ~IFrameSource() = default;
+
+    [[nodiscard]] virtual int Width() const noexcept = 0;
+    [[nodiscard]] virtual int Height() const noexcept = 0;
+    [[nodiscard]] virtual int FrameCount() const noexcept = 0;
+    [[nodiscard]] virtual const FrameBuffer& At(int idx) const = 0;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/pipeline.hpp
+++ b/apps/video_editor/engine/include/video_editor/pipeline.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <video_editor/filter_chain.hpp>
+#include <video_editor/frame_buffer.hpp>
+#include <video_editor/frame_source.hpp>
+
+#include <vector>
+
+namespace cortex::video_editor {
+
+// Orchestrates the source → chain → output transformation. Holds references
+// to the source and chain (caller-owned) and owns the output frame storage.
+// Runners call ProcessFrame() per frame; the UI calls RenderPreview() for
+// fast single-frame updates outside the bulk-apply path.
+class Pipeline final {
+public:
+    Pipeline(const IFrameSource& source, const FilterChain& chain);
+
+    Pipeline(const Pipeline&) = delete;
+    Pipeline& operator=(const Pipeline&) = delete;
+    Pipeline(Pipeline&&) = delete;
+    Pipeline& operator=(Pipeline&&) = delete;
+
+    [[nodiscard]] int Width() const noexcept;
+    [[nodiscard]] int Height() const noexcept;
+    [[nodiscard]] int FrameCount() const noexcept;
+
+    [[nodiscard]] const FrameBuffer& OutputAt(int idx) const;
+
+    // Processes a single frame: reads source[idx], runs the chain, writes to
+    // output[idx]. Used by both the preview path (foreground) and runners.
+    void ProcessFrame(int idx);
+
+    // Convenience: process the current preview frame. Identical to
+    // ProcessFrame today; kept as a separate method so a future caching
+    // strategy can diverge.
+    void RenderPreview(int idx) {
+        ProcessFrame(idx);
+    }
+
+private:
+    const IFrameSource& source_;
+    const FilterChain& chain_;
+    std::vector<FrameBuffer> outputs_;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/procedural_source.hpp
+++ b/apps/video_editor/engine/include/video_editor/procedural_source.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <video_editor/frame_source.hpp>
+
+#include <vector>
+
+namespace cortex::video_editor {
+
+// Generates an animated synthetic "video" into a fixed array of FrameBuffers.
+// All frames are produced at construction time and stored in memory; no I/O,
+// no codecs, no decoding cost during editing. Content is deterministic in
+// (frame_idx, x, y) — useful for tests and reproducible demos.
+//
+// Content recipe per frame:
+//   * Time-varying RGB gradient (sin/cos compositions of frame_idx)
+//   * Three colored discs that orbit / drift around the frame
+class ProceduralFrameSource final : public IFrameSource {
+public:
+    ProceduralFrameSource(int width, int height, int frame_count);
+
+    [[nodiscard]] int Width() const noexcept override {
+        return width_;
+    }
+    [[nodiscard]] int Height() const noexcept override {
+        return height_;
+    }
+    [[nodiscard]] int FrameCount() const noexcept override {
+        return static_cast<int>(frames_.size());
+    }
+    [[nodiscard]] const FrameBuffer& At(int idx) const override;
+
+private:
+    void RenderFrame(int idx, FrameBuffer& out) const;
+
+    int width_;
+    int height_;
+    std::vector<FrameBuffer> frames_;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/progress_listener.hpp
+++ b/apps/video_editor/engine/include/video_editor/progress_listener.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace cortex::video_editor {
+
+// Observer interface for bulk-apply runners to report status. Implemented by
+// the WASM bridge (forwards to EM_JS) and by RecordingListener in tests.
+class IProgressListener {
+public:
+    virtual ~IProgressListener() = default;
+
+    // pct in [0.0, 1.0]
+    virtual void OnProgress(float pct) = 0;
+    virtual void OnComplete() = 0;
+    virtual void OnCancelled() = 0;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/include/video_editor/runner.hpp
+++ b/apps/video_editor/engine/include/video_editor/runner.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace cortex::video_editor {
+
+class Pipeline;
+class IProgressListener;
+
+// Strategy interface for "how is the bulk filter-apply scheduled?".
+// CooperativeRunner uses tiny_fiber, BlockingRunner is a synchronous foil
+// for the side-by-side freeze demo.
+class IRunner {
+public:
+    virtual ~IRunner() = default;
+
+    virtual void Start(Pipeline& pipeline, IProgressListener& listener) = 0;
+    virtual bool Step() = 0;
+    virtual void Cancel() = 0;
+
+    [[nodiscard]] virtual bool IsRunning() const noexcept = 0;
+    [[nodiscard]] virtual float Progress() const noexcept = 0;
+};
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/src/blocking_runner.cpp
+++ b/apps/video_editor/engine/src/blocking_runner.cpp
@@ -1,0 +1,39 @@
+#include <video_editor/blocking_runner.hpp>
+
+#include <video_editor/pipeline.hpp>
+
+namespace cortex::video_editor {
+
+void BlockingRunner::Start(Pipeline& pipeline, IProgressListener& listener) {
+    cancel_requested_ = false;
+    const int total = pipeline.FrameCount();
+    if (total <= 0) {
+        progress_ = 1.0f;
+        listener.OnComplete();
+        return;
+    }
+
+    for (int i = 0; i < total; ++i) {
+        if (cancel_requested_) {
+            listener.OnCancelled();
+            return;
+        }
+        pipeline.ProcessFrame(i);
+        progress_ = static_cast<float>(i + 1) / static_cast<float>(total);
+        listener.OnProgress(progress_);
+    }
+    listener.OnComplete();
+}
+
+bool BlockingRunner::Step() {
+    return false;
+}
+
+void BlockingRunner::Cancel() {
+    // Note: under WASM single-threaded execution the Start() call has already
+    // run to completion by the time JS can call Cancel(). The flag exists so
+    // tests on a separate thread (or future async drivers) can interrupt.
+    cancel_requested_ = true;
+}
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/src/cooperative_runner.cpp
+++ b/apps/video_editor/engine/src/cooperative_runner.cpp
@@ -1,0 +1,120 @@
+#include <video_editor/cooperative_runner.hpp>
+
+#include <video_editor/pipeline.hpp>
+
+#include <cortex/tiny_fiber/errors/scheduler_stopping_error.hpp>
+#include <cortex/tiny_fiber/future.hpp>
+#include <cortex/tiny_fiber/yield.hpp>
+
+#include <algorithm>
+
+namespace cortex::video_editor {
+
+namespace tf = cortex::tiny_fiber;
+
+CooperativeRunner::CooperativeRunner(int workers)
+    : worker_count_(std::max(1, workers)) {}
+
+CooperativeRunner::~CooperativeRunner() = default;
+
+void CooperativeRunner::Start(Pipeline& pipeline, IProgressListener& listener) {
+    pipeline_ = &pipeline;
+    listener_ = &listener;
+    next_frame_ = 0;
+    completed_frames_ = 0;
+    total_frames_ = pipeline.FrameCount();
+    finished_ = false;
+    cancelled_ = false;
+
+    if (total_frames_ <= 0) {
+        finished_ = true;
+        listener.OnComplete();
+        return;
+    }
+
+    const int workers = std::min(worker_count_, total_frames_);
+
+    // The entry fiber spawns workers, waits for them all, then returns.
+    // Workers grab indices from a shared atomic counter (work-stealing style)
+    // so faster workers can pick up slack from slower ones.
+    scheduler_ = tf::Scheduler::Create([this, workers] {
+        std::vector<tf::Future<void>> handles;
+        handles.reserve(static_cast<std::size_t>(workers));
+
+        for (int w = 0; w < workers; ++w) {
+            handles.push_back(tf::Spawn([this] {
+                while (true) {
+                    const int idx = next_frame_.fetch_add(1);
+                    if (idx >= total_frames_) {
+                        return;
+                    }
+                    try {
+                        pipeline_->ProcessFrame(idx);
+                    } catch (const tf::SchedulerStoppingError&) {
+                        return;
+                    }
+                    completed_frames_.fetch_add(1);
+                    // Push progress before yielding so the very last frame's
+                    // progress is observed even if the scheduler shuts down.
+                    listener_->OnProgress(Progress());
+                    try {
+                        tf::Yield();
+                    } catch (const tf::SchedulerStoppingError&) {
+                        return;
+                    }
+                }
+            }));
+        }
+
+        for (auto& h : handles) {
+            try {
+                h.Wait();
+            } catch (const tf::SchedulerStoppingError&) {
+                // Continue waiting on remaining workers under shutdown.
+            }
+        }
+    });
+}
+
+bool CooperativeRunner::Step() {
+    if (!scheduler_ || finished_) {
+        return false;
+    }
+
+    const bool more = scheduler_->Step();
+    if (!more) {
+        DispatchCompletionIfDone();
+    }
+    return more;
+}
+
+void CooperativeRunner::Cancel() {
+    if (!scheduler_ || finished_) {
+        return;
+    }
+    cancelled_ = true;
+    scheduler_->Stop();
+}
+
+float CooperativeRunner::Progress() const noexcept {
+    if (total_frames_ <= 0) {
+        return 1.0f;
+    }
+    const int done = completed_frames_.load();
+    return std::min(1.0f, static_cast<float>(done) / static_cast<float>(total_frames_));
+}
+
+void CooperativeRunner::DispatchCompletionIfDone() {
+    if (finished_) {
+        return;
+    }
+    finished_ = true;
+    if (cancelled_) {
+        listener_->OnCancelled();
+    } else {
+        listener_->OnComplete();
+    }
+    scheduler_.reset();
+}
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/src/editor.cpp
+++ b/apps/video_editor/engine/src/editor.cpp
@@ -1,0 +1,184 @@
+#include <video_editor/editor.hpp>
+
+#include <video_editor/blocking_runner.hpp>
+#include <video_editor/cooperative_runner.hpp>
+#include <video_editor/filter_chain.hpp>
+#include <video_editor/filters/brightness.hpp>
+#include <video_editor/filters/contrast.hpp>
+#include <video_editor/filters/gaussian_blur.hpp>
+#include <video_editor/filters/saturation.hpp>
+#include <video_editor/pipeline.hpp>
+#include <video_editor/procedural_source.hpp>
+
+#include <algorithm>
+
+namespace cortex::video_editor {
+
+class Editor::Impl {
+public:
+    Impl(int width, int height, int frame_count)
+        : source_(width, height, frame_count) {
+        RebuildChain();
+        pipeline_ = std::make_unique<Pipeline>(source_, chain_);
+    }
+
+    int Width() const noexcept {
+        return source_.Width();
+    }
+    int Height() const noexcept {
+        return source_.Height();
+    }
+    int FrameCount() const noexcept {
+        return source_.FrameCount();
+    }
+    const FrameBuffer& Source(int idx) const {
+        return source_.At(idx);
+    }
+    const FrameBuffer& Output(int idx) const {
+        return pipeline_->OutputAt(idx);
+    }
+
+    void SetBrightness(float v) {
+        brightness_ = std::clamp(v, -1.0f, 1.0f);
+        chain_dirty_ = true;
+    }
+    void SetContrast(float v) {
+        contrast_ = std::clamp(v, 0.0f, 2.0f);
+        chain_dirty_ = true;
+    }
+    void SetSaturation(float v) {
+        saturation_ = std::clamp(v, 0.0f, 2.0f);
+        chain_dirty_ = true;
+    }
+    void SetBlurRadius(int r) {
+        blur_radius_ = std::clamp(r, 0, 32);
+        chain_dirty_ = true;
+    }
+
+    void EnsureChain() {
+        if (chain_dirty_) {
+            RebuildChain();
+            chain_dirty_ = false;
+        }
+    }
+
+    void RenderPreview(int idx) {
+        EnsureChain();
+        pipeline_->RenderPreview(idx);
+    }
+
+    void StartCooperativeApply(IProgressListener& listener) {
+        EnsureChain();
+        runner_ = std::make_unique<CooperativeRunner>();
+        runner_->Start(*pipeline_, listener);
+    }
+
+    void RunBlockingApply(IProgressListener& listener) {
+        EnsureChain();
+        runner_ = std::make_unique<BlockingRunner>();
+        runner_->Start(*pipeline_, listener);
+    }
+
+    bool Step() {
+        return runner_ ? runner_->Step() : false;
+    }
+
+    void Cancel() {
+        if (runner_) {
+            runner_->Cancel();
+        }
+    }
+
+    float Progress() const noexcept {
+        return runner_ ? runner_->Progress() : 1.0f;
+    }
+
+private:
+    void RebuildChain() {
+        chain_.Clear();
+        // Order is fixed and chosen for visual sanity: tonal adjustments
+        // first (brightness then contrast then saturation), spatial blur last
+        // so it operates on the already-color-corrected frame.
+        if (brightness_ != 0.0f) {
+            chain_.Add(std::make_unique<filters::BrightnessFilter>(brightness_));
+        }
+        if (contrast_ != 1.0f) {
+            chain_.Add(std::make_unique<filters::ContrastFilter>(contrast_));
+        }
+        if (saturation_ != 1.0f) {
+            chain_.Add(std::make_unique<filters::SaturationFilter>(saturation_));
+        }
+        if (blur_radius_ > 0) {
+            chain_.Add(std::make_unique<filters::GaussianBlurFilter>(blur_radius_));
+        }
+    }
+
+    ProceduralFrameSource source_;
+    FilterChain chain_;
+    std::unique_ptr<Pipeline> pipeline_;
+    std::unique_ptr<IRunner> runner_;
+
+    float brightness_ {0.0f};
+    float contrast_ {1.0f};
+    float saturation_ {1.0f};
+    int blur_radius_ {0};
+    bool chain_dirty_ {false};
+};
+
+std::unique_ptr<Editor> Editor::Create(int width, int height, int frame_count) {
+    auto impl = std::make_unique<Impl>(width, height, frame_count);
+    return std::unique_ptr<Editor>(new Editor(std::move(impl)));
+}
+
+Editor::Editor(std::unique_ptr<Impl> impl) noexcept
+    : impl_(std::move(impl)) {}
+
+Editor::~Editor() = default;
+
+int Editor::Width() const noexcept {
+    return impl_->Width();
+}
+int Editor::Height() const noexcept {
+    return impl_->Height();
+}
+int Editor::FrameCount() const noexcept {
+    return impl_->FrameCount();
+}
+const FrameBuffer& Editor::Source(int idx) const {
+    return impl_->Source(idx);
+}
+const FrameBuffer& Editor::Output(int idx) const {
+    return impl_->Output(idx);
+}
+void Editor::SetBrightness(float v) {
+    impl_->SetBrightness(v);
+}
+void Editor::SetContrast(float v) {
+    impl_->SetContrast(v);
+}
+void Editor::SetSaturation(float v) {
+    impl_->SetSaturation(v);
+}
+void Editor::SetBlurRadius(int r) {
+    impl_->SetBlurRadius(r);
+}
+void Editor::RenderPreview(int idx) {
+    impl_->RenderPreview(idx);
+}
+void Editor::StartCooperativeApply(IProgressListener& l) {
+    impl_->StartCooperativeApply(l);
+}
+void Editor::RunBlockingApply(IProgressListener& l) {
+    impl_->RunBlockingApply(l);
+}
+bool Editor::Step() {
+    return impl_->Step();
+}
+void Editor::Cancel() {
+    impl_->Cancel();
+}
+float Editor::Progress() const noexcept {
+    return impl_->Progress();
+}
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/src/filter_chain.cpp
+++ b/apps/video_editor/engine/src/filter_chain.cpp
@@ -1,0 +1,55 @@
+#include <video_editor/filter_chain.hpp>
+
+#include <cassert>
+#include <utility>
+
+namespace cortex::video_editor {
+
+void FilterChain::Add(std::unique_ptr<IFilter> filter) {
+    if (filter) {
+        filters_.push_back(std::move(filter));
+    }
+}
+
+void FilterChain::Clear() noexcept {
+    filters_.clear();
+}
+
+void FilterChain::Apply(const FrameBuffer& in, FrameBuffer& out) const {
+    assert(in.Width() == out.Width() && in.Height() == out.Height());
+
+    if (filters_.empty()) {
+        out.CopyFrom(in);
+        return;
+    }
+
+    if (filters_.size() == 1) {
+        filters_.front()->Apply(in, out);
+        return;
+    }
+
+    if (scratch_.Width() != in.Width() || scratch_.Height() != in.Height()) {
+        scratch_ = FrameBuffer(in.Width(), in.Height());
+    }
+
+    // Ping-pong: pick the final write target so the very last filter writes
+    // directly into `out`. For N filters there are N reads/writes:
+    //   read    write
+    //   in   -> ping  (filter 0)
+    //   ping -> pong  (filter 1)
+    //   ...
+    //   ?    -> out   (filter N-1)
+    const FrameBuffer* read = &in;
+    FrameBuffer* ping = &scratch_;
+    FrameBuffer* pong = &out;
+
+    const std::size_t n = filters_.size();
+    for (std::size_t i = 0; i < n; ++i) {
+        const bool last = (i + 1 == n);
+        FrameBuffer* write = last ? &out : ((i % 2 == 0) ? ping : pong);
+        filters_[i]->Apply(*read, *write);
+        read = write;
+    }
+}
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/src/filters/brightness.cpp
+++ b/apps/video_editor/engine/src/filters/brightness.cpp
@@ -1,0 +1,37 @@
+#include <video_editor/filters/brightness.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+namespace cortex::video_editor::filters {
+
+namespace {
+
+inline std::uint8_t ClampByte(float v) noexcept {
+    return static_cast<std::uint8_t>(std::clamp(v, 0.0f, 255.0f));
+}
+
+} // namespace
+
+BrightnessFilter::BrightnessFilter(float delta) noexcept
+    : delta_(delta) {}
+
+void BrightnessFilter::Apply(const FrameBuffer& in, FrameBuffer& out) const {
+    assert(in.Width() == out.Width() && in.Height() == out.Height());
+
+    const float shift = delta_ * 255.0f;
+    const auto* src = in.Data();
+    auto* dst = out.Data();
+    const std::size_t pixel_count = static_cast<std::size_t>(in.Width()) * static_cast<std::size_t>(in.Height());
+
+    for (std::size_t i = 0; i < pixel_count; ++i) {
+        const std::size_t off = i * 4u;
+        dst[off + 0] = ClampByte(static_cast<float>(src[off + 0]) + shift);
+        dst[off + 1] = ClampByte(static_cast<float>(src[off + 1]) + shift);
+        dst[off + 2] = ClampByte(static_cast<float>(src[off + 2]) + shift);
+        dst[off + 3] = src[off + 3];
+    }
+}
+
+} // namespace cortex::video_editor::filters

--- a/apps/video_editor/engine/src/filters/contrast.cpp
+++ b/apps/video_editor/engine/src/filters/contrast.cpp
@@ -1,0 +1,35 @@
+#include <video_editor/filters/contrast.hpp>
+
+#include <algorithm>
+#include <cassert>
+
+namespace cortex::video_editor::filters {
+
+namespace {
+
+inline std::uint8_t ClampByte(float v) noexcept {
+    return static_cast<std::uint8_t>(std::clamp(v, 0.0f, 255.0f));
+}
+
+} // namespace
+
+ContrastFilter::ContrastFilter(float gain) noexcept
+    : gain_(gain) {}
+
+void ContrastFilter::Apply(const FrameBuffer& in, FrameBuffer& out) const {
+    assert(in.Width() == out.Width() && in.Height() == out.Height());
+
+    const auto* src = in.Data();
+    auto* dst = out.Data();
+    const std::size_t pixel_count = static_cast<std::size_t>(in.Width()) * static_cast<std::size_t>(in.Height());
+
+    for (std::size_t i = 0; i < pixel_count; ++i) {
+        const std::size_t off = i * 4u;
+        dst[off + 0] = ClampByte((static_cast<float>(src[off + 0]) - 128.0f) * gain_ + 128.0f);
+        dst[off + 1] = ClampByte((static_cast<float>(src[off + 1]) - 128.0f) * gain_ + 128.0f);
+        dst[off + 2] = ClampByte((static_cast<float>(src[off + 2]) - 128.0f) * gain_ + 128.0f);
+        dst[off + 3] = src[off + 3];
+    }
+}
+
+} // namespace cortex::video_editor::filters

--- a/apps/video_editor/engine/src/filters/gaussian_blur.cpp
+++ b/apps/video_editor/engine/src/filters/gaussian_blur.cpp
@@ -1,0 +1,113 @@
+#include <video_editor/filters/gaussian_blur.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+namespace cortex::video_editor::filters {
+
+namespace {
+
+inline std::uint8_t ClampByte(float v) noexcept {
+    return static_cast<std::uint8_t>(std::clamp(v, 0.0f, 255.0f));
+}
+
+std::vector<float> BuildKernel(int radius) {
+    if (radius <= 0) {
+        return {1.0f};
+    }
+    const float sigma = std::max(0.5f, static_cast<float>(radius) / 2.0f);
+    const float two_sigma2 = 2.0f * sigma * sigma;
+
+    std::vector<float> k(static_cast<std::size_t>(2 * radius + 1));
+    float sum = 0.0f;
+    for (int i = -radius; i <= radius; ++i) {
+        const float w = std::exp(-static_cast<float>(i * i) / two_sigma2);
+        k[static_cast<std::size_t>(i + radius)] = w;
+        sum += w;
+    }
+    for (auto& v : k) {
+        v /= sum;
+    }
+    return k;
+}
+
+void BlurHorizontal(const FrameBuffer& in, FrameBuffer& out, const std::vector<float>& kernel, int radius) {
+    const int w = in.Width();
+    const int h = in.Height();
+    const auto* src = in.Data();
+    auto* dst = out.Data();
+
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            float r = 0.0f, g = 0.0f, b = 0.0f;
+            for (int k = -radius; k <= radius; ++k) {
+                const int sx = std::clamp(x + k, 0, w - 1);
+                const std::size_t off =
+                    (static_cast<std::size_t>(y) * static_cast<std::size_t>(w) + static_cast<std::size_t>(sx)) * 4u;
+                const float weight = kernel[static_cast<std::size_t>(k + radius)];
+                r += weight * static_cast<float>(src[off + 0]);
+                g += weight * static_cast<float>(src[off + 1]);
+                b += weight * static_cast<float>(src[off + 2]);
+            }
+            const std::size_t dst_off =
+                (static_cast<std::size_t>(y) * static_cast<std::size_t>(w) + static_cast<std::size_t>(x)) * 4u;
+            dst[dst_off + 0] = ClampByte(r);
+            dst[dst_off + 1] = ClampByte(g);
+            dst[dst_off + 2] = ClampByte(b);
+            dst[dst_off + 3] = src[dst_off + 3];
+        }
+    }
+}
+
+void BlurVertical(const FrameBuffer& in, FrameBuffer& out, const std::vector<float>& kernel, int radius) {
+    const int w = in.Width();
+    const int h = in.Height();
+    const auto* src = in.Data();
+    auto* dst = out.Data();
+
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            float r = 0.0f, g = 0.0f, b = 0.0f;
+            for (int k = -radius; k <= radius; ++k) {
+                const int sy = std::clamp(y + k, 0, h - 1);
+                const std::size_t off =
+                    (static_cast<std::size_t>(sy) * static_cast<std::size_t>(w) + static_cast<std::size_t>(x)) * 4u;
+                const float weight = kernel[static_cast<std::size_t>(k + radius)];
+                r += weight * static_cast<float>(src[off + 0]);
+                g += weight * static_cast<float>(src[off + 1]);
+                b += weight * static_cast<float>(src[off + 2]);
+            }
+            const std::size_t dst_off =
+                (static_cast<std::size_t>(y) * static_cast<std::size_t>(w) + static_cast<std::size_t>(x)) * 4u;
+            dst[dst_off + 0] = ClampByte(r);
+            dst[dst_off + 1] = ClampByte(g);
+            dst[dst_off + 2] = ClampByte(b);
+            dst[dst_off + 3] = src[dst_off + 3];
+        }
+    }
+}
+
+} // namespace
+
+GaussianBlurFilter::GaussianBlurFilter(int radius)
+    : radius_(radius < 0 ? 0 : radius)
+    , kernel_(BuildKernel(radius_)) {}
+
+void GaussianBlurFilter::Apply(const FrameBuffer& in, FrameBuffer& out) const {
+    assert(in.Width() == out.Width() && in.Height() == out.Height());
+
+    if (radius_ == 0) {
+        out.CopyFrom(in);
+        return;
+    }
+
+    if (scratch_.Width() != in.Width() || scratch_.Height() != in.Height()) {
+        scratch_ = FrameBuffer(in.Width(), in.Height());
+    }
+
+    BlurHorizontal(in, scratch_, kernel_, radius_);
+    BlurVertical(scratch_, out, kernel_, radius_);
+}
+
+} // namespace cortex::video_editor::filters

--- a/apps/video_editor/engine/src/filters/saturation.cpp
+++ b/apps/video_editor/engine/src/filters/saturation.cpp
@@ -1,0 +1,40 @@
+#include <video_editor/filters/saturation.hpp>
+
+#include <algorithm>
+#include <cassert>
+
+namespace cortex::video_editor::filters {
+
+namespace {
+
+inline std::uint8_t ClampByte(float v) noexcept {
+    return static_cast<std::uint8_t>(std::clamp(v, 0.0f, 255.0f));
+}
+
+} // namespace
+
+SaturationFilter::SaturationFilter(float scale) noexcept
+    : scale_(scale) {}
+
+void SaturationFilter::Apply(const FrameBuffer& in, FrameBuffer& out) const {
+    assert(in.Width() == out.Width() && in.Height() == out.Height());
+
+    const auto* src = in.Data();
+    auto* dst = out.Data();
+    const std::size_t pixel_count = static_cast<std::size_t>(in.Width()) * static_cast<std::size_t>(in.Height());
+
+    for (std::size_t i = 0; i < pixel_count; ++i) {
+        const std::size_t off = i * 4u;
+        const float r = static_cast<float>(src[off + 0]);
+        const float g = static_cast<float>(src[off + 1]);
+        const float b = static_cast<float>(src[off + 2]);
+        const float luma = 0.299f * r + 0.587f * g + 0.114f * b;
+
+        dst[off + 0] = ClampByte(luma + (r - luma) * scale_);
+        dst[off + 1] = ClampByte(luma + (g - luma) * scale_);
+        dst[off + 2] = ClampByte(luma + (b - luma) * scale_);
+        dst[off + 3] = src[off + 3];
+    }
+}
+
+} // namespace cortex::video_editor::filters

--- a/apps/video_editor/engine/src/frame_buffer.cpp
+++ b/apps/video_editor/engine/src/frame_buffer.cpp
@@ -1,0 +1,32 @@
+#include <video_editor/frame_buffer.hpp>
+
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+
+namespace cortex::video_editor {
+
+FrameBuffer::FrameBuffer(int width, int height)
+    : width_(width)
+    , height_(height)
+    , pixels_(static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4u, 0) {
+    if (width <= 0 || height <= 0) {
+        throw std::invalid_argument("FrameBuffer dimensions must be positive");
+    }
+}
+
+void FrameBuffer::CopyFrom(const FrameBuffer& other) {
+    assert(width_ == other.width_ && height_ == other.height_);
+    std::memcpy(pixels_.data(), other.pixels_.data(), pixels_.size());
+}
+
+void FrameBuffer::Fill(std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a) {
+    for (std::size_t i = 0; i + 3 < pixels_.size(); i += 4) {
+        pixels_[i] = r;
+        pixels_[i + 1] = g;
+        pixels_[i + 2] = b;
+        pixels_[i + 3] = a;
+    }
+}
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/src/pipeline.cpp
+++ b/apps/video_editor/engine/src/pipeline.cpp
@@ -1,0 +1,42 @@
+#include <video_editor/pipeline.hpp>
+
+#include <stdexcept>
+
+namespace cortex::video_editor {
+
+Pipeline::Pipeline(const IFrameSource& source, const FilterChain& chain)
+    : source_(source)
+    , chain_(chain) {
+    outputs_.reserve(static_cast<std::size_t>(source.FrameCount()));
+    for (int i = 0; i < source.FrameCount(); ++i) {
+        outputs_.emplace_back(source.Width(), source.Height());
+    }
+}
+
+int Pipeline::Width() const noexcept {
+    return source_.Width();
+}
+
+int Pipeline::Height() const noexcept {
+    return source_.Height();
+}
+
+int Pipeline::FrameCount() const noexcept {
+    return static_cast<int>(outputs_.size());
+}
+
+const FrameBuffer& Pipeline::OutputAt(int idx) const {
+    if (idx < 0 || idx >= static_cast<int>(outputs_.size())) {
+        throw std::out_of_range("Pipeline::OutputAt: index out of range");
+    }
+    return outputs_[static_cast<std::size_t>(idx)];
+}
+
+void Pipeline::ProcessFrame(int idx) {
+    if (idx < 0 || idx >= static_cast<int>(outputs_.size())) {
+        throw std::out_of_range("Pipeline::ProcessFrame: index out of range");
+    }
+    chain_.Apply(source_.At(idx), outputs_[static_cast<std::size_t>(idx)]);
+}
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/src/procedural_source.cpp
+++ b/apps/video_editor/engine/src/procedural_source.cpp
@@ -1,0 +1,123 @@
+#include <video_editor/procedural_source.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <stdexcept>
+
+namespace cortex::video_editor {
+
+namespace {
+
+inline std::uint8_t ClampByte(float v) noexcept {
+    return static_cast<std::uint8_t>(std::clamp(v, 0.0f, 255.0f));
+}
+
+struct Disc {
+    float cx; // center x in pixels
+    float cy; // center y in pixels
+    float r; // radius in pixels
+    std::uint8_t cr;
+    std::uint8_t cg;
+    std::uint8_t cb;
+};
+
+// Returns three orbiting discs for the given frame index. Centers move along
+// Lissajous figures so the motion is smooth and infinite.
+std::array<Disc, 3> ComputeDiscs(int frame_idx, int width, int height) {
+    const float t = static_cast<float>(frame_idx) * 0.04f;
+    const float w = static_cast<float>(width);
+    const float h = static_cast<float>(height);
+    const float r = std::min(w, h) * 0.12f;
+
+    std::array<Disc, 3> discs {{
+        {0.50f * w + 0.30f * w * std::sin(t * 1.1f + 0.0f),
+         0.50f * h + 0.25f * h * std::cos(t * 1.3f + 1.0f),
+         r,
+         235,
+         88,
+         96},
+        {0.50f * w + 0.28f * w * std::sin(t * 0.7f + 2.0f),
+         0.50f * h + 0.30f * h * std::cos(t * 0.9f + 3.0f),
+         r * 0.85f,
+         96,
+         200,
+         235},
+        {0.50f * w + 0.32f * w * std::cos(t * 1.5f + 4.5f),
+         0.50f * h + 0.22f * h * std::sin(t * 1.8f + 5.5f),
+         r * 1.1f,
+         235,
+         210,
+         96},
+    }};
+    return discs;
+}
+
+} // namespace
+
+ProceduralFrameSource::ProceduralFrameSource(int width, int height, int frame_count)
+    : width_(width)
+    , height_(height) {
+    if (width <= 0 || height <= 0 || frame_count <= 0) {
+        throw std::invalid_argument("ProceduralFrameSource dimensions must be positive");
+    }
+    frames_.reserve(static_cast<std::size_t>(frame_count));
+    for (int i = 0; i < frame_count; ++i) {
+        FrameBuffer fb(width, height);
+        RenderFrame(i, fb);
+        frames_.push_back(std::move(fb));
+    }
+}
+
+const FrameBuffer& ProceduralFrameSource::At(int idx) const {
+    if (idx < 0 || idx >= static_cast<int>(frames_.size())) {
+        throw std::out_of_range("ProceduralFrameSource::At: index out of range");
+    }
+    return frames_[static_cast<std::size_t>(idx)];
+}
+
+void ProceduralFrameSource::RenderFrame(int idx, FrameBuffer& out) const {
+    const float t = static_cast<float>(idx) * 0.05f;
+    const auto discs = ComputeDiscs(idx, width_, height_);
+    auto* dst = out.Data();
+
+    for (int y = 0; y < height_; ++y) {
+        const float fy = static_cast<float>(y) / static_cast<float>(height_);
+        for (int x = 0; x < width_; ++x) {
+            const float fx = static_cast<float>(x) / static_cast<float>(width_);
+
+            // Background gradient: layered sinusoids in three channels.
+            const float br = 0.5f + 0.5f * std::sin((fx + t * 0.3f) * 4.0f);
+            const float bg = 0.5f + 0.5f * std::sin((fy * 3.0f + t * 0.5f) * 1.7f);
+            const float bb = 0.5f + 0.5f * std::sin(((fx + fy) * 2.5f + t * 0.7f));
+
+            float r = br * 220.0f + 30.0f;
+            float g = bg * 200.0f + 35.0f;
+            float b = bb * 230.0f + 25.0f;
+
+            // Composite anti-aliased discs over the gradient.
+            for (const auto& d : discs) {
+                const float dx = static_cast<float>(x) - d.cx;
+                const float dy = static_cast<float>(y) - d.cy;
+                const float dist = std::sqrt(dx * dx + dy * dy);
+                const float edge = d.r;
+                const float aa = 1.5f; // anti-alias width in px
+                const float alpha = std::clamp((edge - dist) / aa, 0.0f, 1.0f);
+                if (alpha > 0.0f) {
+                    r = r * (1.0f - alpha) + static_cast<float>(d.cr) * alpha;
+                    g = g * (1.0f - alpha) + static_cast<float>(d.cg) * alpha;
+                    b = b * (1.0f - alpha) + static_cast<float>(d.cb) * alpha;
+                }
+            }
+
+            const std::size_t off =
+                (static_cast<std::size_t>(y) * static_cast<std::size_t>(width_) + static_cast<std::size_t>(x)) * 4u;
+            dst[off + 0] = ClampByte(r);
+            dst[off + 1] = ClampByte(g);
+            dst[off + 2] = ClampByte(b);
+            dst[off + 3] = 255;
+        }
+    }
+}
+
+} // namespace cortex::video_editor

--- a/apps/video_editor/engine/tests/filter_chain_test.cpp
+++ b/apps/video_editor/engine/tests/filter_chain_test.cpp
@@ -1,0 +1,81 @@
+#include <video_editor/filter_chain.hpp>
+#include <video_editor/filters/brightness.hpp>
+#include <video_editor/filters/contrast.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace cortex::video_editor;
+using namespace cortex::video_editor::filters;
+
+namespace {
+
+FrameBuffer MakeSolid(int w, int h, std::uint8_t r, std::uint8_t g, std::uint8_t b) {
+    FrameBuffer fb(w, h);
+    fb.Fill(r, g, b, 255);
+    return fb;
+}
+
+} // namespace
+
+TEST(FilterChainTest, EmptyChainCopiesInput) {
+    auto in = MakeSolid(3, 3, 10, 20, 30);
+    FrameBuffer out(3, 3);
+    FilterChain chain;
+    chain.Apply(in, out);
+    EXPECT_EQ(out.Data()[0], 10);
+    EXPECT_EQ(out.Data()[1], 20);
+    EXPECT_EQ(out.Data()[2], 30);
+}
+
+TEST(FilterChainTest, SingleFilterWritesDirectlyToOutput) {
+    auto in = MakeSolid(2, 2, 100, 100, 100);
+    FrameBuffer out(2, 2);
+    FilterChain chain;
+    chain.Add(std::make_unique<BrightnessFilter>(0.2f));
+    chain.Apply(in, out);
+    EXPECT_EQ(out.Data()[0], 151);
+}
+
+TEST(FilterChainTest, OppositeBrightnessShiftsApproximatelyCancel) {
+    // Brightness is byte-quantized per stage; ±0.1 doesn't round-trip exactly
+    // but should stay within a unit of the source value.
+    auto in = MakeSolid(2, 2, 80, 120, 160);
+    FrameBuffer out(2, 2);
+    FilterChain chain;
+    chain.Add(std::make_unique<BrightnessFilter>(0.1f));
+    chain.Add(std::make_unique<BrightnessFilter>(-0.1f));
+    chain.Apply(in, out);
+    EXPECT_NEAR(out.Data()[0], 80, 1);
+    EXPECT_NEAR(out.Data()[1], 120, 1);
+    EXPECT_NEAR(out.Data()[2], 160, 1);
+}
+
+TEST(FilterChainTest, OrderMattersForContrastThenBrightness) {
+    auto in = MakeSolid(2, 2, 200, 200, 200);
+    FrameBuffer out_a(2, 2);
+    FrameBuffer out_b(2, 2);
+
+    // Contrast then brightness vs brightness then contrast: should differ for
+    // a non-midgray input.
+    FilterChain a;
+    a.Add(std::make_unique<ContrastFilter>(1.5f));
+    a.Add(std::make_unique<BrightnessFilter>(0.05f));
+    a.Apply(in, out_a);
+
+    FilterChain b;
+    b.Add(std::make_unique<BrightnessFilter>(0.05f));
+    b.Add(std::make_unique<ContrastFilter>(1.5f));
+    b.Apply(in, out_b);
+
+    EXPECT_NE(out_a.Data()[0], out_b.Data()[0]);
+}
+
+TEST(FilterChainTest, ClearRestoresEmptyBehavior) {
+    auto in = MakeSolid(2, 2, 50, 60, 70);
+    FrameBuffer out(2, 2);
+    FilterChain chain;
+    chain.Add(std::make_unique<BrightnessFilter>(0.5f));
+    chain.Clear();
+    chain.Apply(in, out);
+    EXPECT_EQ(out.Data()[0], 50);
+}

--- a/apps/video_editor/engine/tests/filters_test.cpp
+++ b/apps/video_editor/engine/tests/filters_test.cpp
@@ -1,0 +1,138 @@
+#include <video_editor/filters/brightness.hpp>
+#include <video_editor/filters/contrast.hpp>
+#include <video_editor/filters/gaussian_blur.hpp>
+#include <video_editor/filters/saturation.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace cortex::video_editor;
+using namespace cortex::video_editor::filters;
+
+namespace {
+
+FrameBuffer MakeSolid(int w, int h, std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a = 255) {
+    FrameBuffer fb(w, h);
+    fb.Fill(r, g, b, a);
+    return fb;
+}
+
+std::uint8_t Pixel(const FrameBuffer& fb, int x, int y, int channel) {
+    const std::size_t off =
+        (static_cast<std::size_t>(y) * static_cast<std::size_t>(fb.Width()) + static_cast<std::size_t>(x)) * 4u +
+        static_cast<std::size_t>(channel);
+    return fb.Data()[off];
+}
+
+} // namespace
+
+TEST(FiltersTest, BrightnessZeroIsIdentity) {
+    auto in = MakeSolid(4, 4, 100, 150, 200);
+    FrameBuffer out(4, 4);
+    BrightnessFilter f(0.0f);
+    f.Apply(in, out);
+    EXPECT_EQ(Pixel(out, 0, 0, 0), 100);
+    EXPECT_EQ(Pixel(out, 0, 0, 1), 150);
+    EXPECT_EQ(Pixel(out, 0, 0, 2), 200);
+}
+
+TEST(FiltersTest, BrightnessPositiveLightens) {
+    auto in = MakeSolid(2, 2, 100, 100, 100);
+    FrameBuffer out(2, 2);
+    BrightnessFilter f(0.2f); // +51
+    f.Apply(in, out);
+    EXPECT_EQ(Pixel(out, 0, 0, 0), 151);
+}
+
+TEST(FiltersTest, BrightnessSaturatesAtMax) {
+    auto in = MakeSolid(2, 2, 250, 250, 250);
+    FrameBuffer out(2, 2);
+    BrightnessFilter f(1.0f); // +255 clamps to 255
+    f.Apply(in, out);
+    EXPECT_EQ(Pixel(out, 0, 0, 0), 255);
+}
+
+TEST(FiltersTest, ContrastOneIsIdentity) {
+    auto in = MakeSolid(2, 2, 64, 128, 200);
+    FrameBuffer out(2, 2);
+    ContrastFilter f(1.0f);
+    f.Apply(in, out);
+    EXPECT_EQ(Pixel(out, 0, 0, 0), 64);
+    EXPECT_EQ(Pixel(out, 0, 0, 1), 128);
+    EXPECT_EQ(Pixel(out, 0, 0, 2), 200);
+}
+
+TEST(FiltersTest, ContrastZeroFlattensToMidGray) {
+    auto in = MakeSolid(2, 2, 0, 128, 255);
+    FrameBuffer out(2, 2);
+    ContrastFilter f(0.0f);
+    f.Apply(in, out);
+    EXPECT_EQ(Pixel(out, 0, 0, 0), 128);
+    EXPECT_EQ(Pixel(out, 0, 0, 1), 128);
+    EXPECT_EQ(Pixel(out, 0, 0, 2), 128);
+}
+
+TEST(FiltersTest, SaturationOneIsIdentity) {
+    auto in = MakeSolid(2, 2, 200, 100, 50);
+    FrameBuffer out(2, 2);
+    SaturationFilter f(1.0f);
+    f.Apply(in, out);
+    EXPECT_EQ(Pixel(out, 0, 0, 0), 200);
+    EXPECT_EQ(Pixel(out, 0, 0, 1), 100);
+    EXPECT_EQ(Pixel(out, 0, 0, 2), 50);
+}
+
+TEST(FiltersTest, SaturationZeroProducesGrayscale) {
+    auto in = MakeSolid(2, 2, 200, 100, 50);
+    FrameBuffer out(2, 2);
+    SaturationFilter f(0.0f);
+    f.Apply(in, out);
+    // luma = 0.299*200 + 0.587*100 + 0.114*50 ≈ 124
+    const auto r = Pixel(out, 0, 0, 0);
+    EXPECT_EQ(r, Pixel(out, 0, 0, 1));
+    EXPECT_EQ(r, Pixel(out, 0, 0, 2));
+    EXPECT_GE(r, 120);
+    EXPECT_LE(r, 130);
+}
+
+TEST(FiltersTest, GaussianBlurRadiusZeroIsIdentity) {
+    auto in = MakeSolid(4, 4, 80, 160, 240);
+    // Mark center pixel
+    in.Data()[(1 * 4 + 1) * 4 + 0] = 0;
+    FrameBuffer out(4, 4);
+    GaussianBlurFilter f(0);
+    f.Apply(in, out);
+    EXPECT_EQ(Pixel(out, 0, 0, 0), 80);
+    EXPECT_EQ(Pixel(out, 1, 1, 0), 0);
+}
+
+TEST(FiltersTest, GaussianBlurSpreadsImpulse) {
+    FrameBuffer in(7, 7);
+    in.Fill(0, 0, 0, 255);
+    // Single bright center pixel.
+    const std::size_t center = (3 * 7 + 3) * 4;
+    in.Data()[center + 0] = 255;
+    in.Data()[center + 1] = 255;
+    in.Data()[center + 2] = 255;
+
+    FrameBuffer out(7, 7);
+    GaussianBlurFilter f(2);
+    f.Apply(in, out);
+
+    // The center should still be the brightest pixel.
+    const auto center_val = Pixel(out, 3, 3, 0);
+    // Adjacent pixels should be brighter than zero (the impulse spread).
+    EXPECT_GT(Pixel(out, 2, 3, 0), 0);
+    EXPECT_GT(Pixel(out, 3, 2, 0), 0);
+    EXPECT_GT(Pixel(out, 4, 3, 0), 0);
+    EXPECT_GT(Pixel(out, 3, 4, 0), 0);
+    // Pixels far from center should be dimmer than the center.
+    EXPECT_LT(Pixel(out, 0, 0, 0), center_val);
+}
+
+TEST(FiltersTest, GaussianBlurPreservesAlpha) {
+    auto in = MakeSolid(5, 5, 200, 200, 200, 137);
+    FrameBuffer out(5, 5);
+    GaussianBlurFilter f(2);
+    f.Apply(in, out);
+    EXPECT_EQ(Pixel(out, 2, 2, 3), 137);
+}

--- a/apps/video_editor/engine/tests/pipeline_test.cpp
+++ b/apps/video_editor/engine/tests/pipeline_test.cpp
@@ -1,0 +1,83 @@
+#include <video_editor/filter_chain.hpp>
+#include <video_editor/filters/brightness.hpp>
+#include <video_editor/frame_source.hpp>
+#include <video_editor/pipeline.hpp>
+#include <video_editor/progress_listener.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace cortex::video_editor;
+using namespace cortex::video_editor::filters;
+
+namespace {
+
+// Test double: a frame source built from caller-supplied buffers.
+class FakeFrameSource final : public IFrameSource {
+public:
+    FakeFrameSource(int w, int h, int count, std::uint8_t base) {
+        for (int i = 0; i < count; ++i) {
+            FrameBuffer fb(w, h);
+            fb.Fill(static_cast<std::uint8_t>(base + i), 0, 0, 255);
+            frames_.push_back(std::move(fb));
+        }
+        width_ = w;
+        height_ = h;
+    }
+    int Width() const noexcept override {
+        return width_;
+    }
+    int Height() const noexcept override {
+        return height_;
+    }
+    int FrameCount() const noexcept override {
+        return static_cast<int>(frames_.size());
+    }
+    const FrameBuffer& At(int idx) const override {
+        return frames_[static_cast<std::size_t>(idx)];
+    }
+
+private:
+    std::vector<FrameBuffer> frames_;
+    int width_ {0};
+    int height_ {0};
+};
+
+} // namespace
+
+TEST(PipelineTest, OutputsMatchSourceWhenChainEmpty) {
+    FakeFrameSource src(4, 4, 3, 50);
+    FilterChain chain;
+    Pipeline pipeline(src, chain);
+
+    for (int i = 0; i < pipeline.FrameCount(); ++i) {
+        pipeline.ProcessFrame(i);
+    }
+
+    EXPECT_EQ(pipeline.OutputAt(0).Data()[0], 50);
+    EXPECT_EQ(pipeline.OutputAt(1).Data()[0], 51);
+    EXPECT_EQ(pipeline.OutputAt(2).Data()[0], 52);
+}
+
+TEST(PipelineTest, FilterAppliedToEveryFrame) {
+    FakeFrameSource src(2, 2, 4, 100);
+    FilterChain chain;
+    chain.Add(std::make_unique<BrightnessFilter>(0.1f)); // +25
+    Pipeline pipeline(src, chain);
+
+    pipeline.ProcessFrame(0);
+    pipeline.ProcessFrame(3);
+
+    EXPECT_EQ(pipeline.OutputAt(0).Data()[0], 125);
+    EXPECT_EQ(pipeline.OutputAt(3).Data()[0], 128);
+}
+
+TEST(PipelineTest, OutOfRangeThrows) {
+    FakeFrameSource src(2, 2, 2, 0);
+    FilterChain chain;
+    Pipeline pipeline(src, chain);
+    EXPECT_THROW(pipeline.ProcessFrame(-1), std::out_of_range);
+    EXPECT_THROW(pipeline.ProcessFrame(2), std::out_of_range);
+    EXPECT_THROW({ (void)pipeline.OutputAt(-1); }, std::out_of_range);
+}

--- a/apps/video_editor/engine/tests/runners_test.cpp
+++ b/apps/video_editor/engine/tests/runners_test.cpp
@@ -1,0 +1,156 @@
+#include <video_editor/blocking_runner.hpp>
+#include <video_editor/cooperative_runner.hpp>
+#include <video_editor/filter_chain.hpp>
+#include <video_editor/filters/brightness.hpp>
+#include <video_editor/frame_source.hpp>
+#include <video_editor/pipeline.hpp>
+#include <video_editor/progress_listener.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+using namespace cortex::video_editor;
+using namespace cortex::video_editor::filters;
+
+namespace {
+
+class FakeFrameSource final : public IFrameSource {
+public:
+    FakeFrameSource(int w, int h, int count) {
+        for (int i = 0; i < count; ++i) {
+            FrameBuffer fb(w, h);
+            fb.Fill(static_cast<std::uint8_t>(10 + i), 0, 0, 255);
+            frames_.push_back(std::move(fb));
+        }
+        width_ = w;
+        height_ = h;
+    }
+    int Width() const noexcept override {
+        return width_;
+    }
+    int Height() const noexcept override {
+        return height_;
+    }
+    int FrameCount() const noexcept override {
+        return static_cast<int>(frames_.size());
+    }
+    const FrameBuffer& At(int idx) const override {
+        return frames_[static_cast<std::size_t>(idx)];
+    }
+
+private:
+    std::vector<FrameBuffer> frames_;
+    int width_ {0};
+    int height_ {0};
+};
+
+class RecordingListener final : public IProgressListener {
+public:
+    void OnProgress(float pct) override {
+        progresses.push_back(pct);
+    }
+    void OnComplete() override {
+        completed = true;
+    }
+    void OnCancelled() override {
+        cancelled = true;
+    }
+
+    std::vector<float> progresses;
+    bool completed {false};
+    bool cancelled {false};
+};
+
+} // namespace
+
+TEST(RunnersTest, BlockingProducesAllOutputs) {
+    FakeFrameSource src(4, 4, 6);
+    FilterChain chain;
+    chain.Add(std::make_unique<BrightnessFilter>(0.1f));
+    Pipeline pipeline(src, chain);
+
+    RecordingListener listener;
+    BlockingRunner runner;
+    runner.Start(pipeline, listener);
+
+    EXPECT_TRUE(listener.completed);
+    EXPECT_FALSE(listener.cancelled);
+    EXPECT_EQ(listener.progresses.size(), 6u);
+    EXPECT_FLOAT_EQ(listener.progresses.back(), 1.0f);
+}
+
+TEST(RunnersTest, CooperativeProducesAllOutputs) {
+    FakeFrameSource src(4, 4, 8);
+    FilterChain chain;
+    chain.Add(std::make_unique<BrightnessFilter>(0.1f));
+    Pipeline pipeline(src, chain);
+
+    RecordingListener listener;
+    CooperativeRunner runner(3);
+    runner.Start(pipeline, listener);
+
+    int safety = 0;
+    while (runner.Step() && safety++ < 10000) {
+    }
+    // Step() returning false either means the scheduler is done or there are
+    // no more ready fibers; the runner dispatches OnComplete on that final step.
+
+    EXPECT_TRUE(listener.completed);
+    EXPECT_FALSE(listener.cancelled);
+    EXPECT_FLOAT_EQ(runner.Progress(), 1.0f);
+}
+
+TEST(RunnersTest, BothRunnersProduceIdenticalOutputs) {
+    FakeFrameSource src(8, 8, 5);
+
+    FilterChain chain_a;
+    chain_a.Add(std::make_unique<BrightnessFilter>(0.05f));
+    Pipeline pipeline_a(src, chain_a);
+    RecordingListener listener_a;
+    BlockingRunner blocking;
+    blocking.Start(pipeline_a, listener_a);
+
+    FilterChain chain_b;
+    chain_b.Add(std::make_unique<BrightnessFilter>(0.05f));
+    Pipeline pipeline_b(src, chain_b);
+    RecordingListener listener_b;
+    CooperativeRunner cooperative(2);
+    cooperative.Start(pipeline_b, listener_b);
+    int safety = 0;
+    while (cooperative.Step() && safety++ < 10000) {
+    }
+
+    ASSERT_EQ(pipeline_a.FrameCount(), pipeline_b.FrameCount());
+    for (int i = 0; i < pipeline_a.FrameCount(); ++i) {
+        const auto& a = pipeline_a.OutputAt(i);
+        const auto& b = pipeline_b.OutputAt(i);
+        ASSERT_EQ(a.SizeBytes(), b.SizeBytes());
+        EXPECT_EQ(std::memcmp(a.Data(), b.Data(), a.SizeBytes()), 0)
+            << "Frame " << i << " differs between blocking and cooperative runners";
+    }
+}
+
+TEST(RunnersTest, CooperativeCancelDispatchesOnCancelled) {
+    FakeFrameSource src(4, 4, 40);
+    FilterChain chain;
+    chain.Add(std::make_unique<BrightnessFilter>(0.1f));
+    Pipeline pipeline(src, chain);
+
+    RecordingListener listener;
+    CooperativeRunner runner(2);
+    runner.Start(pipeline, listener);
+
+    // Run a couple of steps then cancel.
+    runner.Step();
+    runner.Step();
+    runner.Cancel();
+
+    int safety = 0;
+    while (runner.Step() && safety++ < 10000) {
+    }
+
+    EXPECT_TRUE(listener.cancelled);
+    EXPECT_FALSE(listener.completed);
+}

--- a/apps/video_editor/web/index.html
+++ b/apps/video_editor/web/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cortex Video Editor</title>
+    <link rel="stylesheet" href="./styles/main.css">
+</head>
+<body>
+    <header class="topbar">
+        <div id="liveness-spinner" class="spinner" aria-hidden="true"></div>
+        <h1>Cortex Video Editor</h1>
+        <span class="subtitle">A tiny_fiber demo — heavy filtering without freezing the UI.</span>
+    </header>
+
+    <main class="layout">
+        <section class="preview">
+            <canvas id="preview-canvas" width="320" height="240"></canvas>
+        </section>
+
+        <section class="timeline">
+            <label for="timeline-input">Timeline</label>
+            <input id="timeline-input" type="range" min="0" max="0" step="1" value="0">
+            <span id="timeline-label" class="timeline-label">0 / 0</span>
+        </section>
+
+        <section class="controls">
+            <fieldset>
+                <legend>Filters</legend>
+                <div class="slider-row">
+                    <label for="slider-brightness">Brightness</label>
+                    <input id="slider-brightness" type="range" min="-1" max="1" step="0.01" value="0">
+                </div>
+                <div class="slider-row">
+                    <label for="slider-contrast">Contrast</label>
+                    <input id="slider-contrast" type="range" min="0" max="2" step="0.01" value="1">
+                </div>
+                <div class="slider-row">
+                    <label for="slider-saturation">Saturation</label>
+                    <input id="slider-saturation" type="range" min="0" max="2" step="0.01" value="1">
+                </div>
+                <div class="slider-row">
+                    <label for="slider-blur">Blur radius</label>
+                    <input id="slider-blur" type="range" min="0" max="16" step="1" value="0">
+                </div>
+            </fieldset>
+
+            <fieldset>
+                <legend>Apply</legend>
+                <div class="button-row">
+                    <button id="btn-apply-cooperative" class="primary">Apply (cooperative)</button>
+                    <button id="btn-apply-blocking">Apply (blocking)</button>
+                    <button id="btn-cancel">Cancel</button>
+                    <button id="btn-ab">A / B</button>
+                </div>
+                <div class="progress">
+                    <div class="bar-track">
+                        <div id="progress-bar" class="bar-fill"></div>
+                    </div>
+                    <span id="progress-label" class="progress-label">0%</span>
+                </div>
+                <div id="status-label" class="status">Idle</div>
+            </fieldset>
+        </section>
+
+        <section class="info">
+            <h2>How to read this demo</h2>
+            <ul>
+                <li>The <span class="badge">spinner</span> in the top-left animates via <code>requestAnimationFrame</code>. If it freezes, the main thread is blocked.</li>
+                <li><strong>Apply (blocking)</strong> runs the filter chain synchronously. The spinner stops, the timeline goes unresponsive, the progress bar jumps to 100% only after the work is done.</li>
+                <li><strong>Apply (cooperative)</strong> runs the same work via <code>cortex::tiny_fiber</code> &mdash; workers <code>Yield()</code> between frames, the spinner keeps spinning, and the timeline stays draggable.</li>
+                <li><strong>Cancel</strong> calls <code>Scheduler::Stop()</code>; workers catch <code>SchedulerStoppingError</code> and exit cleanly.</li>
+                <li><strong>A / B</strong> toggles between the source frame and the edited output.</li>
+            </ul>
+        </section>
+    </main>
+
+    <script type="module" src="./src/main.js"></script>
+</body>
+</html>

--- a/apps/video_editor/web/styles/main.css
+++ b/apps/video_editor/web/styles/main.css
@@ -1,0 +1,290 @@
+:root {
+    --bg: #16181d;
+    --bg-elevated: #1f2229;
+    --bg-input: #2a2e36;
+    --border: #2e323b;
+    --text: #d8dee9;
+    --text-dim: #8a8f99;
+    --accent: #5fa8d3;
+    --accent-strong: #79b8e0;
+    --accent-bg: #294053;
+    --danger: #d9534f;
+    --good: #8bc34a;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.topbar {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-elevated);
+}
+
+.topbar h1 {
+    font-size: 18px;
+    margin: 0;
+    color: var(--text);
+}
+
+.subtitle {
+    color: var(--text-dim);
+    font-size: 13px;
+}
+
+.spinner {
+    width: 22px;
+    height: 22px;
+    border: 3px solid var(--accent-bg);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    /* Animated via JS requestAnimationFrame — no CSS keyframes, so we can
+       visibly see it freeze when the main thread is blocked. */
+}
+
+.layout {
+    display: grid;
+    grid-template-columns: 1fr 360px;
+    grid-template-rows: auto auto;
+    grid-template-areas:
+        "preview  controls"
+        "timeline controls"
+        "info     info";
+    gap: 16px;
+    padding: 20px;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.preview {
+    grid-area: preview;
+    background: black;
+    border-radius: 8px;
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border);
+}
+
+.preview canvas {
+    width: 100%;
+    max-width: 640px;
+    height: auto;
+    image-rendering: pixelated;
+    background: #0a0b0d;
+    border-radius: 4px;
+}
+
+.timeline {
+    grid-area: timeline;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.timeline label {
+    color: var(--text-dim);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.timeline input {
+    flex: 1;
+}
+
+.timeline-label {
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    min-width: 80px;
+    text-align: right;
+}
+
+.controls {
+    grid-area: controls;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+fieldset {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 16px;
+}
+
+legend {
+    padding: 0 8px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 11px;
+}
+
+.slider-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 6px 0;
+}
+
+.slider-row label {
+    flex: 0 0 96px;
+    color: var(--text-dim);
+    font-size: 12px;
+}
+
+.slider-row input {
+    flex: 1;
+}
+
+input[type="range"] {
+    accent-color: var(--accent);
+    background: transparent;
+}
+
+input[type="range"]:disabled {
+    opacity: 0.45;
+}
+
+.button-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+button {
+    background: var(--bg-input);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 6px 12px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: background 80ms ease-out;
+}
+
+button:hover:not(:disabled) {
+    background: #353a44;
+}
+
+button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+button.primary {
+    background: var(--accent-bg);
+    border-color: var(--accent);
+    color: var(--accent-strong);
+}
+
+button.primary:hover:not(:disabled) {
+    background: #344e66;
+}
+
+.progress {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 6px;
+}
+
+.bar-track {
+    flex: 1;
+    height: 8px;
+    background: var(--bg-input);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.bar-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--accent);
+    transition: width 100ms ease-out;
+}
+
+.progress-label {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-dim);
+    min-width: 40px;
+    text-align: right;
+}
+
+.status {
+    color: var(--text-dim);
+    font-size: 12px;
+    margin-top: 4px;
+}
+
+.info {
+    grid-area: info;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 16px;
+    color: var(--text-dim);
+    font-size: 13px;
+}
+
+.info h2 {
+    margin: 0 0 8px;
+    font-size: 14px;
+    color: var(--text);
+}
+
+.info ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.info li {
+    margin-bottom: 6px;
+}
+
+.info code {
+    background: var(--bg-input);
+    padding: 1px 5px;
+    border-radius: 3px;
+    color: var(--accent-strong);
+    font-size: 12px;
+}
+
+.badge {
+    background: var(--accent-bg);
+    color: var(--accent-strong);
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+
+@media (max-width: 760px) {
+    .layout {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "preview"
+            "timeline"
+            "controls"
+            "info";
+    }
+}

--- a/cmake/AppRuntime.cmake
+++ b/cmake/AppRuntime.cmake
@@ -1,0 +1,64 @@
+# Shared helper for building WASM applications under apps/.
+#
+# Each app builds a single Emscripten executable that exposes a small C ABI
+# to JavaScript and ships a static web bundle alongside. The build flags are
+# common across apps, so we encapsulate them here.
+
+if(NOT EMSCRIPTEN)
+    # Native builds skip apps entirely; the helper is a no-op so callers
+    # don't need to wrap their cortex_add_wasm_app_runtime() calls.
+    function(cortex_add_wasm_app_runtime)
+    endfunction()
+    return()
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(_CORTEX_APP_OPT_FLAGS "-Os")
+    set(_CORTEX_APP_ASSERT_FLAG "-sASSERTIONS=0")
+else()
+    set(_CORTEX_APP_OPT_FLAGS "-O0")
+    set(_CORTEX_APP_ASSERT_FLAG "-sASSERTIONS=1")
+endif()
+
+set(CORTEX_WASM_APP_LINK_FLAGS
+    "-sALLOW_MEMORY_GROWTH=1"
+    "-sEXIT_RUNTIME=0"
+    "-sASYNCIFY_STACK_SIZE=65536"
+    "-sENVIRONMENT=web"
+    "-sINCOMING_MODULE_JS_API=['locateFile','onAbort','onRuntimeInitialized']"
+    "-sEXPORTED_RUNTIME_METHODS=['UTF8ToString']"
+    "${_CORTEX_APP_ASSERT_FLAG}"
+    "${_CORTEX_APP_OPT_FLAGS}"
+)
+
+# cortex_add_wasm_app_runtime(TARGET OUTPUT_NAME EXPORTED_FUNCTIONS SOURCES...)
+#
+# TARGET             — CMake target name for the executable.
+# OUTPUT_NAME        — Basename of the produced .js / .wasm files.
+# EXPORTED_FUNCTIONS — String value for -sEXPORTED_FUNCTIONS=[...]
+#                     (e.g. "['_main','_my_func']"). Function names need a
+#                     leading underscore.
+# SOURCES            — One or more .cpp files; passed to add_executable.
+function(cortex_add_wasm_app_runtime TARGET OUTPUT_NAME EXPORTED_FUNCTIONS)
+    set(_sources ${ARGN})
+    if(NOT _sources)
+        message(FATAL_ERROR
+            "cortex_add_wasm_app_runtime(${TARGET}): no source files provided")
+    endif()
+
+    add_executable(${TARGET} ${_sources})
+
+    set_target_properties(${TARGET} PROPERTIES
+        SUFFIX ".js"
+        OUTPUT_NAME "${OUTPUT_NAME}"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    )
+
+    target_link_options(${TARGET} PRIVATE
+        "-sEXPORTED_FUNCTIONS=${EXPORTED_FUNCTIONS}"
+        ${CORTEX_WASM_APP_LINK_FLAGS}
+    )
+
+    cortex_apply_warnings(${TARGET})
+    cortex_apply_sanitizers(${TARGET})
+endfunction()

--- a/dev.sh
+++ b/dev.sh
@@ -25,6 +25,7 @@ print_usage() {
     echo "  example-wasm      Build and run WASM example"
     echo "  serve             Serve WASM example in browser"
     echo "  algoviz           Build and serve AlgoViz BST Visualizer"
+    echo "  video-editor      Build and serve Video Editor demo"
     echo "  clean             Clean all build artifacts"
     echo "  format            Format all C++ code"
     echo "  shell             Open shell in development container"
@@ -77,6 +78,15 @@ case "${1:-help}" in
         echo ""
         echo -e "${YELLOW}Tip: To build in Debug mode, run: BUILD_TYPE=Debug ./dev.sh algoviz${NC}"
         docker compose up --build serve-algoviz
+        ;;
+    video-editor)
+        echo -e "${GREEN}Building and serving Video Editor demo...${NC}"
+        echo -e "${YELLOW}Building in Release mode (optimized)${NC}"
+        echo ""
+        echo -e "  ${GREEN}→ http://localhost:8080${NC} ${YELLOW}(Cortex Video Editor)${NC}"
+        echo ""
+        echo -e "${YELLOW}Tip: To build in Debug mode, run: BUILD_TYPE=Debug ./dev.sh video-editor${NC}"
+        docker compose up --build serve-video-editor
         ;;
     clean)
         echo -e "${YELLOW}Cleaning build artifacts...${NC}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,3 +111,27 @@ services:
         cd build/wasm-algoviz/apps/algo_viz &&
         python3 -m http.server 8080
         "
+
+  # 8. Build and Serve Video Editor
+  serve-video-editor:
+      build: .
+      volumes:
+        - .:/workspace
+      ports:
+        - "8080:8080"
+      environment:
+        - BUILD_TYPE=${BUILD_TYPE:-Release}
+      command: >
+        bash -c "
+        source /opt/emsdk/emsdk_env.sh &&
+        rm -rf build/wasm-video-editor &&
+        emcmake cmake -B build/wasm-video-editor -G Ninja -DCMAKE_BUILD_TYPE=$${BUILD_TYPE} -DCORTEX_BUILD_APPS=ON &&
+        cmake --build build/wasm-video-editor --config $${BUILD_TYPE} --target video_editor &&
+        echo '' &&
+        echo '✅ Video Editor built successfully in $${BUILD_TYPE} mode!' &&
+        echo '' &&
+        echo '  → http://localhost:8080' &&
+        echo '' &&
+        cd build/wasm-video-editor/apps/video_editor &&
+        python3 -m http.server 8080
+        "


### PR DESCRIPTION
A new WASM demo that puts cortex::tiny_fiber through its paces: applying a heavy Gaussian-blur filter pipeline to every frame of a procedurally generated 320×240×180-frame "video", with a side-by-side comparison between a blocking implementation (which freezes the UI) and a cooperative one (which keeps an always-spinning element animating, the timeline draggable, and the progress bar updating smoothly).

Architecture
------------

The engine is a proper layered C++ library, not a single main.cpp:

  * IFrameSource (strategy)       — ProceduralFrameSource generates frames
  * IFilter (strategy)            — BrightnessFilter / ContrastFilter /
                                    SaturationFilter / GaussianBlurFilter
  * FilterChain (composition)     — holds vector<unique_ptr<IFilter>>;
                                    ping-pong scratch buffer between stages
  * Pipeline                      — orchestrates source -> chain -> output
  * IProgressListener (observer)  — runners report status; the WASM bridge
                                    is one implementation, RecordingListener
                                    in tests is another
  * IRunner (strategy)            — CooperativeRunner uses tf::Scheduler +
                                    Spawn/Yield/Stop with 3 worker fibers;
                                    BlockingRunner is a synchronous foil
  * Editor (facade, PIMPL)        — the single class the WASM bridge sees

The bridge (engine/bridge/wasm_bridge.cpp) is pure translation: extern "C" forwarders, JsProgressListener that relays into JS via EM_JS. No engine logic lives there.

The JS side mirrors the C++ separation: WasmModule, EditorClient (wraps the C ABI), CanvasRenderer, TimelineControl, FilterControls, ApplyControls, ProgressView, SpinnerLiveness, with EditorApp as the controller and main.js as the composition root.

Build / tests
-------------

* New cmake/AppRuntime.cmake hosts cortex_add_wasm_app_runtime() — the Emscripten link-flag block previously inlined in apps/algo_viz is now shared; algo_viz refactored to use it.
* The engine compiles as video_editor_engine (static library) for both WASM and native — natively it powers video_editor_engine_test (24 new gtest cases) covering filters, FilterChain composition, Pipeline, and parity between the two runners including Cancel().
* Apps subdir is now added under CORTEX_BUILD_APPS OR CORTEX_BUILD_TESTS so the engine tests run as part of the regular ctest invocation.
* All 125 tests pass under default and ASan/UBSan builds (101 original + 24 video_editor).

Infrastructure
--------------

* docker-compose adds serve-video-editor (mirrors serve-algoviz).
* dev.sh adds a `video-editor` subcommand.
* deploy-demo.yml builds the new target and publishes it to /<repo>/video-editor/index.html alongside the existing demos.