### PR TITLE
Diagnose video-editor deploy assertion failure

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -81,27 +81,47 @@ jobs:
           # Copy docs
           cp -R doc/html/. deploy/docs/
 
-          # Fail fast if required AlgoViz assets are missing
-          test -f deploy/algoviz/index.html
-          test -f deploy/algoviz/bst.html
-          test -f deploy/algoviz/union_find.html
-          test -f deploy/algoviz/src/main.js
-          test -f deploy/algoviz/src/js/theme.js
-          test -f deploy/algoviz/src/js/union_find.js
-          test -f deploy/algoviz/src/styles/main.css
-          test -f deploy/algoviz/algoviz_bst.js
-          test -f deploy/algoviz/algoviz_bst.wasm
-          test -f deploy/algoviz/algoviz_union_find.js
-          test -f deploy/algoviz/algoviz_union_find.wasm
+          # Diagnostics — show what got built and what landed in deploy/
+          echo "=== build/wasm-video-editor/apps/video_editor/ ==="
+          ls -la build/wasm-video-editor/apps/video_editor/ || true
+          echo "=== deploy/video-editor/ (top level) ==="
+          ls -la deploy/video-editor/ || true
+          echo "=== deploy/video-editor/src/ ==="
+          ls -la deploy/video-editor/src/ || true
+          echo "=== deploy/video-editor/styles/ ==="
+          ls -la deploy/video-editor/styles/ || true
 
-          # Fail fast if required Video Editor assets are missing
-          test -f deploy/video-editor/index.html
-          test -f deploy/video-editor/src/main.js
-          test -f deploy/video-editor/src/editor_app.js
-          test -f deploy/video-editor/src/editor_client.js
-          test -f deploy/video-editor/styles/main.css
-          test -f deploy/video-editor/video_editor.js
-          test -f deploy/video-editor/video_editor.wasm
+          # Verify required assets. Loop so we surface every missing file
+          # instead of stopping silently on the first failing `test -f`.
+          missing=0
+          for f in \
+              deploy/algoviz/index.html \
+              deploy/algoviz/bst.html \
+              deploy/algoviz/union_find.html \
+              deploy/algoviz/src/main.js \
+              deploy/algoviz/src/js/theme.js \
+              deploy/algoviz/src/js/union_find.js \
+              deploy/algoviz/src/styles/main.css \
+              deploy/algoviz/algoviz_bst.js \
+              deploy/algoviz/algoviz_bst.wasm \
+              deploy/algoviz/algoviz_union_find.js \
+              deploy/algoviz/algoviz_union_find.wasm \
+              deploy/video-editor/index.html \
+              deploy/video-editor/src/main.js \
+              deploy/video-editor/src/editor_app.js \
+              deploy/video-editor/src/editor_client.js \
+              deploy/video-editor/styles/main.css \
+              deploy/video-editor/video_editor.js \
+              deploy/video-editor/video_editor.wasm
+          do
+              if [ ! -f "$f" ]; then
+                  echo "MISSING: $f"
+                  missing=1
+              fi
+          done
+          if [ "$missing" -ne 0 ]; then
+              exit 1
+          fi
 
           # Create a root index.html that links to everything
           cat > deploy/index.html << 'EOF'


### PR DESCRIPTION
Run #28 on main fails in the 'Prepare deployment directory' step but bash's set -e swallows which `test -f` failed. Replace the per-file asserts with:
 * `ls -la` of the build output and each deploy subdir, so the next run prints exactly what was produced
 * a loop that surfaces every missing file before exiting non-zero

No behavior change when everything is present.