### PR TITLE
Restore missing video_editor web/src/*.js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ doc/
 !apps/algo_viz/web/src/main.js
 !apps/algo_viz/web/src/js/*.js
 
+# Keep VideoEditor frontend source JS files in git
+!apps/video_editor/web/src/*.js
+
 # CMake
 CMakeCache.txt
 CMakeFiles/

--- a/apps/video_editor/web/src/canvas.js
+++ b/apps/video_editor/web/src/canvas.js
@@ -1,0 +1,21 @@
+// Renders a frame's RGBA buffer onto a <canvas>. Constructs an ImageData
+// from the Uint8ClampedArray view once per draw — cheap; this is the
+// preview path that runs on every slider change and every animation frame.
+
+export class CanvasRenderer {
+    constructor(canvasEl) {
+        this._canvas = canvasEl;
+        this._ctx = canvasEl.getContext("2d", { willReadFrequently: false });
+    }
+
+    resize(width, height) {
+        this._canvas.width = width;
+        this._canvas.height = height;
+    }
+
+    draw(pixels, width, height) {
+        if (!pixels) return;
+        const img = new ImageData(new Uint8ClampedArray(pixels), width, height);
+        this._ctx.putImageData(img, 0, 0);
+    }
+}

--- a/apps/video_editor/web/src/controls.js
+++ b/apps/video_editor/web/src/controls.js
@@ -1,0 +1,55 @@
+// FilterControls — four range sliders. Emits 'change' with {key, value}.
+// ApplyControls — three buttons + AB toggle. Emits 'apply-cooperative',
+//   'apply-blocking', 'cancel', 'toggle-ab' events.
+
+export class FilterControls extends EventTarget {
+    constructor(sliders) {
+        super();
+        // sliders: { brightness, contrast, saturation, blur }
+        this._inputs = sliders;
+        for (const [key, el] of Object.entries(sliders)) {
+            el.addEventListener("input", () => {
+                this.dispatchEvent(new CustomEvent("change", {
+                    detail: { key, value: Number(el.value) },
+                }));
+            });
+        }
+    }
+
+    values() {
+        return {
+            brightness: Number(this._inputs.brightness.value),
+            contrast:   Number(this._inputs.contrast.value),
+            saturation: Number(this._inputs.saturation.value),
+            blur:       Number(this._inputs.blur.value),
+        };
+    }
+
+    setEnabled(enabled) {
+        for (const el of Object.values(this._inputs)) {
+            el.disabled = !enabled;
+        }
+    }
+}
+
+export class ApplyControls extends EventTarget {
+    constructor(buttons) {
+        super();
+        // buttons: { cooperative, blocking, cancel, ab }
+        this._btn = buttons;
+        buttons.cooperative.addEventListener("click", () =>
+            this.dispatchEvent(new Event("apply-cooperative")));
+        buttons.blocking.addEventListener("click", () =>
+            this.dispatchEvent(new Event("apply-blocking")));
+        buttons.cancel.addEventListener("click", () =>
+            this.dispatchEvent(new Event("cancel")));
+        buttons.ab.addEventListener("click", () =>
+            this.dispatchEvent(new Event("toggle-ab")));
+    }
+
+    setRunning(running) {
+        this._btn.cooperative.disabled = running;
+        this._btn.blocking.disabled = running;
+        this._btn.cancel.disabled = !running;
+    }
+}

--- a/apps/video_editor/web/src/editor_app.js
+++ b/apps/video_editor/web/src/editor_app.js
@@ -1,0 +1,139 @@
+// Controller class. Subscribes to UI events, drives the EditorClient, owns
+// the canvas-refresh and scheduler-step rAF loops. Holds the small amount
+// of mutable state (current frame, AB-mode flag, run state) the demo needs.
+
+export class EditorApp {
+    constructor({ client, canvas, timeline, filters, apply, progress }) {
+        this._client = client;
+        this._canvas = canvas;
+        this._timeline = timeline;
+        this._filters = filters;
+        this._apply = apply;
+        this._progress = progress;
+
+        this._currentFrame = 0;
+        this._showOutput = true;
+        this._running = false;
+        this._stepRafId = 0;
+    }
+
+    init(width, height, frameCount) {
+        if (!this._client.init(width, height, frameCount)) {
+            throw new Error("editor_init returned false");
+        }
+        this._canvas.resize(width, height);
+        this._timeline.setFrameCount(frameCount);
+        this._installBridgeCallbacks();
+        this._wireEvents();
+        // Initial preview at frame 0.
+        this._applyFilterValues();
+        this._client.renderPreview(0);
+        this._redraw();
+        this._progress.setStatus("Ready");
+    }
+
+    _wireEvents() {
+        this._timeline.addEventListener("seek", (e) => {
+            this._currentFrame = e.detail;
+            // Skip live re-render while a cooperative run is in progress —
+            // its rAF loop will pick up the new frame anyway, and we don't
+            // want to fight it for the filter chain.
+            if (!this._running) {
+                this._client.renderPreview(this._currentFrame);
+            }
+            this._redraw();
+        });
+
+        this._filters.addEventListener("change", () => {
+            this._applyFilterValues();
+            if (!this._running) {
+                this._client.renderPreview(this._currentFrame);
+                this._redraw();
+            }
+        });
+
+        this._apply.addEventListener("apply-cooperative", () => this._startCooperative());
+        this._apply.addEventListener("apply-blocking", () => this._runBlocking());
+        this._apply.addEventListener("cancel", () => this._client.cancel());
+        this._apply.addEventListener("toggle-ab", () => {
+            this._showOutput = !this._showOutput;
+            this._redraw();
+            this._progress.setStatus(this._showOutput ? "Showing: edited" : "Showing: source");
+        });
+    }
+
+    _applyFilterValues() {
+        const v = this._filters.values();
+        this._client.setBrightness(v.brightness);
+        this._client.setContrast(v.contrast);
+        this._client.setSaturation(v.saturation);
+        this._client.setBlurRadius(v.blur);
+    }
+
+    _installBridgeCallbacks() {
+        window.onApplyProgress = (pct) => {
+            this._progress.set(pct);
+        };
+        window.onApplyComplete = () => {
+            this._running = false;
+            this._apply.setRunning(false);
+            this._progress.set(1);
+            this._progress.setStatus("Apply complete");
+            this._client.renderPreview(this._currentFrame);
+            this._redraw();
+        };
+        window.onApplyCancelled = () => {
+            this._running = false;
+            this._apply.setRunning(false);
+            this._progress.setStatus("Cancelled");
+        };
+    }
+
+    _startCooperative() {
+        if (this._running) return;
+        this._applyFilterValues();
+        this._progress.set(0);
+        this._progress.setStatus("Applying (cooperative)…");
+        this._running = true;
+        this._apply.setRunning(true);
+        this._client.startApplyCooperative();
+        this._driveSteps();
+    }
+
+    _runBlocking() {
+        if (this._running) return;
+        this._applyFilterValues();
+        this._progress.set(0);
+        this._progress.setStatus("Applying (blocking)…");
+        this._running = true;
+        this._apply.setRunning(true);
+        // Synchronous call — the UI will be frozen until it returns. That's
+        // the whole point of this code path; the cooperative button is the
+        // foil. Defer one tick so the status label has a chance to paint.
+        window.setTimeout(() => {
+            this._client.runApplyBlocking();
+            // onApplyComplete will reset state from inside the bridge.
+        }, 16);
+    }
+
+    _driveSteps() {
+        const tick = () => {
+            if (!this._running) return;
+            const more = this._client.step();
+            // Refresh the displayed frame as workers finish frames.
+            this._client.renderPreview(this._currentFrame);
+            this._redraw();
+            if (more) {
+                this._stepRafId = window.requestAnimationFrame(tick);
+            }
+        };
+        this._stepRafId = window.requestAnimationFrame(tick);
+    }
+
+    _redraw() {
+        const pixels = this._showOutput
+            ? this._client.outputFrame(this._currentFrame)
+            : this._client.sourceFrame(this._currentFrame);
+        this._canvas.draw(pixels, this._client.width(), this._client.height());
+    }
+}

--- a/apps/video_editor/web/src/editor_client.js
+++ b/apps/video_editor/web/src/editor_client.js
@@ -1,0 +1,51 @@
+// Thin object-oriented wrapper around the Module._editor_* C ABI. Other JS
+// modules talk to this class, never directly to the Emscripten Module. Keeps
+// the "this is the boundary" surface clear and makes it trivial to mock in
+// future tests.
+
+export class EditorClient {
+    constructor(module) {
+        this._mod = module;
+    }
+
+    init(width, height, frameCount) {
+        return this._mod._editor_init(width, height, frameCount) === 1;
+    }
+
+    width()       { return this._mod._editor_get_width(); }
+    height()      { return this._mod._editor_get_height(); }
+    frameCount()  { return this._mod._editor_get_frame_count(); }
+
+    setBrightness(v)  { this._mod._editor_set_brightness(v); }
+    setContrast(v)    { this._mod._editor_set_contrast(v); }
+    setSaturation(v)  { this._mod._editor_set_saturation(v); }
+    setBlurRadius(r)  { this._mod._editor_set_blur_radius(r); }
+
+    renderPreview(frameIdx) {
+        this._mod._editor_render_preview(frameIdx);
+    }
+
+    startApplyCooperative() { this._mod._editor_start_apply_cooperative(); }
+    runApplyBlocking()      { this._mod._editor_apply_blocking(); }
+    step()                  { return this._mod._editor_step() === 1; }
+    cancel()                { this._mod._editor_cancel(); }
+    progress()              { return this._mod._editor_get_progress(); }
+
+    // Returns a Uint8ClampedArray view into the WASM heap holding the
+    // requested frame's RGBA pixels. The view is invalidated whenever the
+    // heap grows; callers should not retain it across yields.
+    sourceFrame(frameIdx) {
+        const ptr = this._mod._editor_get_source_frame(frameIdx);
+        return this._frameView(ptr);
+    }
+    outputFrame(frameIdx) {
+        const ptr = this._mod._editor_get_output_frame(frameIdx);
+        return this._frameView(ptr);
+    }
+
+    _frameView(ptr) {
+        if (!ptr) return null;
+        const size = this.width() * this.height() * 4;
+        return new Uint8ClampedArray(this._mod.HEAPU8.buffer, ptr, size);
+    }
+}

--- a/apps/video_editor/web/src/liveness.js
+++ b/apps/video_editor/web/src/liveness.js
@@ -1,0 +1,34 @@
+// Continuously rotates an element via requestAnimationFrame. This is the
+// "smoking gun" element on the page: if it stops rotating, the main thread
+// is blocked. The blocking-apply demo deliberately triggers that freeze;
+// the cooperative-apply path is the proof that the same workload doesn't.
+
+export class SpinnerLiveness {
+    constructor(element) {
+        this._el = element;
+        this._angle = 0;
+        this._last = performance.now();
+        this._rafId = 0;
+    }
+
+    start() {
+        if (this._rafId !== 0) return;
+        const tick = (now) => {
+            const dt = now - this._last;
+            this._last = now;
+            // 1 full rotation per ~1.5s.
+            this._angle = (this._angle + (dt / 1500) * 360) % 360;
+            this._el.style.transform = `rotate(${this._angle.toFixed(1)}deg)`;
+            this._rafId = window.requestAnimationFrame(tick);
+        };
+        this._last = performance.now();
+        this._rafId = window.requestAnimationFrame(tick);
+    }
+
+    stop() {
+        if (this._rafId !== 0) {
+            window.cancelAnimationFrame(this._rafId);
+            this._rafId = 0;
+        }
+    }
+}

--- a/apps/video_editor/web/src/main.js
+++ b/apps/video_editor/web/src/main.js
@@ -1,0 +1,59 @@
+// Composition root. Instantiates every module, wires them together, and
+// hands control to EditorApp.
+
+import { loadWasmRuntime } from "./wasm.js";
+import { EditorClient } from "./editor_client.js";
+import { CanvasRenderer } from "./canvas.js";
+import { TimelineControl } from "./timeline.js";
+import { FilterControls, ApplyControls } from "./controls.js";
+import { ProgressView } from "./progress.js";
+import { SpinnerLiveness } from "./liveness.js";
+import { EditorApp } from "./editor_app.js";
+
+const FRAME_WIDTH = 320;
+const FRAME_HEIGHT = 240;
+const FRAME_COUNT = 180;
+
+async function main() {
+    const $ = (id) => document.getElementById(id);
+
+    const spinner = new SpinnerLiveness($("liveness-spinner"));
+    spinner.start();
+
+    const progress = new ProgressView($("progress-bar"), $("progress-label"), $("status-label"));
+    progress.setStatus("Loading WASM…");
+
+    let module;
+    try {
+        module = await loadWasmRuntime();
+    } catch (err) {
+        progress.setStatus(`Failed to load: ${err.message}`);
+        return;
+    }
+
+    const client = new EditorClient(module);
+    const canvas = new CanvasRenderer($("preview-canvas"));
+    const timeline = new TimelineControl($("timeline-input"), $("timeline-label"));
+    const filters = new FilterControls({
+        brightness: $("slider-brightness"),
+        contrast:   $("slider-contrast"),
+        saturation: $("slider-saturation"),
+        blur:       $("slider-blur"),
+    });
+    const apply = new ApplyControls({
+        cooperative: $("btn-apply-cooperative"),
+        blocking:    $("btn-apply-blocking"),
+        cancel:      $("btn-cancel"),
+        ab:          $("btn-ab"),
+    });
+    apply.setRunning(false);
+
+    progress.setStatus("Generating procedural frames…");
+    // Defer to next frame so the status update paints.
+    window.requestAnimationFrame(() => {
+        const app = new EditorApp({ client, canvas, timeline, filters, apply, progress });
+        app.init(FRAME_WIDTH, FRAME_HEIGHT, FRAME_COUNT);
+    });
+}
+
+main();

--- a/apps/video_editor/web/src/progress.js
+++ b/apps/video_editor/web/src/progress.js
@@ -1,0 +1,25 @@
+// Renders progress 0..1 to a fixed-width bar element and a percent label.
+
+export class ProgressView {
+    constructor(barEl, labelEl, statusEl) {
+        this._bar = barEl;
+        this._label = labelEl;
+        this._status = statusEl;
+        this.set(0);
+        this.setStatus("Idle");
+    }
+
+    set(pct) {
+        const clamped = Math.max(0, Math.min(1, pct));
+        this._bar.style.width = `${(clamped * 100).toFixed(1)}%`;
+        if (this._label) {
+            this._label.textContent = `${(clamped * 100).toFixed(0)}%`;
+        }
+    }
+
+    setStatus(text) {
+        if (this._status) {
+            this._status.textContent = text;
+        }
+    }
+}

--- a/apps/video_editor/web/src/timeline.js
+++ b/apps/video_editor/web/src/timeline.js
@@ -1,0 +1,47 @@
+// Timeline scrubber: a range input + label showing current frame index.
+// Emits 'seek' events when the user drags; programmatic updates via
+// .setFrame() do NOT fire 'seek' (to avoid feedback loops with the canvas).
+
+export class TimelineControl extends EventTarget {
+    constructor(inputEl, labelEl) {
+        super();
+        this._input = inputEl;
+        this._label = labelEl;
+        this._total = 0;
+        this._input.addEventListener("input", () => {
+            const idx = Number(this._input.value);
+            this._updateLabel(idx);
+            this.dispatchEvent(new CustomEvent("seek", { detail: idx }));
+        });
+    }
+
+    setFrameCount(total) {
+        this._total = total;
+        this._input.min = 0;
+        this._input.max = Math.max(0, total - 1);
+        if (Number(this._input.value) >= total) {
+            this._input.value = String(total - 1);
+        }
+        this._updateLabel(Number(this._input.value));
+    }
+
+    setFrame(idx) {
+        if (idx < 0 || idx >= this._total) return;
+        this._input.value = String(idx);
+        this._updateLabel(idx);
+    }
+
+    currentFrame() {
+        return Number(this._input.value);
+    }
+
+    setEnabled(enabled) {
+        this._input.disabled = !enabled;
+    }
+
+    _updateLabel(idx) {
+        if (this._label) {
+            this._label.textContent = `${idx + 1} / ${this._total}`;
+        }
+    }
+}

--- a/apps/video_editor/web/src/wasm.js
+++ b/apps/video_editor/web/src/wasm.js
@@ -1,0 +1,23 @@
+// Loads the Emscripten-generated runtime script (`video_editor.js`) and
+// resolves to the initialized Module object. Identical pattern to algo_viz.
+
+export function loadWasmRuntime() {
+    return new Promise((resolve, reject) => {
+        const runtimeUrl = "./video_editor.js";
+        const runtimeHref = new URL(runtimeUrl, window.location.href).href;
+        const moduleObj = {};
+        moduleObj.locateFile = (path, scriptDirectory) => {
+            const base = scriptDirectory || runtimeHref;
+            return new URL(path, base).href;
+        };
+        moduleObj.onAbort = (msg) => reject(new Error(msg || "WASM aborted"));
+        moduleObj.onRuntimeInitialized = () => resolve(moduleObj);
+        window.Module = moduleObj;
+
+        const script = document.createElement("script");
+        script.src = runtimeUrl;
+        script.async = true;
+        script.onerror = () => reject(new Error(`Failed to load ${runtimeUrl}`));
+        document.head.appendChild(script);
+    });
+}


### PR DESCRIPTION
The squash-merge of #31 kept only the diagnostic workflow change and silently dropped the .gitignore + JS-file additions that were on the second commit of that branch, so the production deploy still fails on test -f for src/main.js / src/editor_app.js / src/editor_client.js.

This change re-applies the actual fix:
 * .gitignore whitelists apps/video_editor/web/src/*.js so the JS files stop being swallowed by the global *.js Emscripten-output rule
 * adds the 9 previously-missing JS modules: canvas.js, controls.js, editor_app.js, editor_client.js, liveness.js, main.js, progress.js, timeline.js, wasm.js

The diagnostic loop from #31 will confirm the next deploy run is clean.