### PR TITLE
perf(video-editor): speed up the cooperative WASM render path

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -252,9 +252,28 @@ python3 -m http.server 8080
 
 ## CMake Options
 
-- `CORTEX_BUILD_TESTS` - Build unit tests (default: ON)
-- `CORTEX_BUILD_EXAMPLES` - Build example applications (default: OFF)
+- `CORTEX_BUILD_TESTS` - Build the library + per-component test binaries, including the native `apps/video_editor` engine tests (default: ON)
+- `CORTEX_BUILD_EXAMPLES` - Build the standalone WASM demos in `examples/` (default: OFF)
+- `CORTEX_BUILD_APPS` - Build the full apps: `apps/algo_viz` and `apps/video_editor` (default: OFF)
 - `CORTEX_USE_SANITIZERS` - Enable Address and Undefined Behavior sanitizers (default: OFF). Works for both Native and WASM builds.
+
+## Building the Browser Demos
+
+The demos are WASM apps; build them with Emscripten and `CORTEX_BUILD_APPS=ON`.
+
+```bash
+# AlgoViz
+emcmake cmake -B build/wasm-algoviz -G Ninja -DCMAKE_BUILD_TYPE=Release -DCORTEX_BUILD_APPS=ON
+cmake --build build/wasm-algoviz --config Release --target algo_viz
+
+# Video Editor
+emcmake cmake -B build/wasm-video-editor -G Ninja -DCMAKE_BUILD_TYPE=Release -DCORTEX_BUILD_APPS=ON
+cmake --build build/wasm-video-editor --config Release --target video_editor
+```
+
+Serve either bundle with any static HTTP server (`python3 -m http.server 8080`) from its build directory, or use the helper script (`./dev.sh algoviz`, `./dev.sh video-editor`), which builds and serves in one step.
+
+Release WASM app builds use `-O3 -msimd128`, tuned for the video editor's per-pixel filter math (see `cmake/AppRuntime.cmake`). The cooperative renderer keeps the page responsive by filtering each frame in row-bands and yielding between them via `tiny_fiber`.
 
 ## Platform Detection
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,34 @@
 # Cortex
 
-**A C++23 stackful coroutine library that keeps the UI responsive — in the browser, via WebAssembly.**
+**C++23 stackful coroutines that keep the browser responsive.**
 
 [![Live Demo](https://img.shields.io/badge/demo-live-brightgreen?style=for-the-badge)](https://GhevondW.github.io/cortex/)
 [![Docs](https://img.shields.io/badge/docs-doxygen-blue?style=for-the-badge)](https://GhevondW.github.io/cortex/docs/)
 
-Heavy C++ work (image filters, recursive search, simulation loops) normally blocks the browser's main thread and freezes the page. Cortex gives you **stackful coroutines + a cooperative fiber scheduler** that the JS event loop can drive **one step at a time**, so the same algorithm finishes a frame, yields, lets the browser repaint, and resumes — no Web Workers, no threads, no rewrites of your hot path.
+Heavy C++ work — image filters, recursive search, simulation loops — normally blocks the browser's main thread and freezes the page. Cortex runs it as **stackful coroutines on a cooperative fiber scheduler** that the JS event loop drives **one step at a time**: the algorithm does a slice of work, yields, lets the browser repaint, and resumes. No Web Workers, no threads, no rewrite of your hot path.
 
-## Live Demos
+## Live demos
 
-Try them in your browser, no installation required.
+No install — open in a browser:
 
-- **[Video Editor](https://GhevondW.github.io/cortex/video-editor/index.html)** — open a video from your computer and **edit it live while it plays**: brightness, contrast, saturation and blur applied to every displayed frame in C++/WASM, in real time. Flip on the **Cortex cooperative engine** and crank the blur — the page never freezes (the "smoking gun" spinner keeps spinning). **New, recommended.**
-- **[AlgoViz — BST Visualizer](https://GhevondW.github.io/cortex/algoviz/)** — interactive binary-search-tree algorithms.
-- **[Sudoku Solver](https://GhevondW.github.io/cortex/examples/sudoku_demo.html)** — recursive backtracking visualised live.
+- **[Video Editor](https://GhevondW.github.io/cortex/video-editor/index.html)** — open a local video and edit it **while it plays**: brightness, contrast, saturation and blur applied to every frame in C++/WASM. Turn on the Cortex cooperative engine, crank the blur, and the page never freezes.
+- **[AlgoViz](https://GhevondW.github.io/cortex/algoviz/)** — interactive binary-search-tree and union-find algorithms.
+- **[Sudoku Solver](https://GhevondW.github.io/cortex/examples/sudoku_demo.html)** — recursive backtracking, visualised live.
 - **[Particle Simulation](https://GhevondW.github.io/cortex/examples/particle_demo.html)** — heavy compute vs. cooperative scheduling, side by side.
-- **[Fiber Workflow](https://GhevondW.github.io/cortex/examples/fiber_demo.html)** — producer / worker pattern with `tiny_fiber`.
-- **[Basic Example](https://GhevondW.github.io/cortex/examples/index.html)** — minimal suspend / resume.
-- **[All Demos](https://GhevondW.github.io/cortex/)** · **[API Docs](https://GhevondW.github.io/cortex/docs/)**
+- **[All demos](https://GhevondW.github.io/cortex/)** · **[API docs](https://GhevondW.github.io/cortex/docs/)**
 
 ## What you get
 
-| | |
+| API | Purpose |
 |---|---|
-| `Coroutine` / `BaseCoroutine` / `Generator` | Stackful suspend / resume with a `MemoryResource` abstraction for custom allocators. Backed by **Boost.Context** natively and **Emscripten Asyncify** under WASM. |
-| `tiny_fiber::Scheduler` | Cooperative fiber scheduler with a **step-based API** — drive it from `requestAnimationFrame` and the page never freezes. `Run()` for native, `Create()` + `Step()` for WASM. |
-| `tiny_fiber::Future<T>` / `Spawn` / `Yield` | Async result handling plus explicit yield points; deliver exceptions via `Future::Get()`. |
-| `tiny_fiber::Mutex` / `ConditionVariable` | Cooperative synchronisation primitives — no OS threads, robust against `Stop()` mid-wait. |
-| **Cross-platform from one codebase** | Same headers / sources compile to a native static library *and* to a `.js` + `.wasm` bundle. |
+| `Coroutine` / `BaseCoroutine` / `Generator` | Stackful suspend/resume with a `MemoryResource` allocator hook. Boost.Context natively, Emscripten Asyncify under WASM. |
+| `tiny_fiber::Scheduler` | Cooperative fiber scheduler with a step-based API: `Run()` natively, `Create()` + `Step()` to drive from `requestAnimationFrame`. |
+| `tiny_fiber::Future<T>` / `Spawn` / `Yield` | Async results and explicit yield points; exceptions delivered via `Future::Get()`. |
+| `tiny_fiber::Mutex` / `ConditionVariable` | Cooperative sync primitives — no OS threads, safe across `Stop()`. |
 
-## Quick Example
+The same headers and sources compile to a native static library **and** a `.js` + `.wasm` bundle.
+
+## Example
 
 ```cpp
 #include <cortex/tiny_fiber/tiny_fiber.hpp>
@@ -48,7 +47,7 @@ int main() {
 }
 ```
 
-### Driving the scheduler from the JS event loop (WASM)
+**Driving it from JS (WASM)** — create the scheduler once, then step it from `requestAnimationFrame`:
 
 ```cpp
 auto scheduler = tf::Scheduler::Create([]{
@@ -63,107 +62,20 @@ auto scheduler = tf::Scheduler::Create([]{
 extern "C" int step() { return scheduler->Step() ? 1 : 0; }
 ```
 
-This is the exact pattern used by the [Video Editor demo](https://GhevondW.github.io/cortex/video-editor/index.html): each displayed video frame is filtered in horizontal row-bands that `Yield()` via `tiny_fiber`, so even a heavy blur never freezes the page while the clip plays.
+This is exactly how the Video Editor filters each frame in yielding row-bands, so even a heavy blur never freezes the page.
 
-## Quick Start
+## Quick start
 
-The simplest path is Docker; everything below assumes Docker + Docker Compose are installed.
-
-### Helper script
+Docker is the only requirement:
 
 ```bash
-./dev.sh test-all         # Run all native + WASM tests
-./dev.sh test-native      # Native tests only
-./dev.sh test-wasm        # WASM tests in Node.js
-./dev.sh serve            # Serve the WASM example bundle  → http://localhost:8080
-./dev.sh algoviz          # Build & serve AlgoViz          → http://localhost:8080
-./dev.sh video-editor     # Build & serve the Video Editor → http://localhost:8080
-./dev.sh format           # clang-format the C++ tree
-./dev.sh shell            # Open a shell in the dev container
-./dev.sh help             # All commands
+./dev.sh test-all       # native + WASM tests
+./dev.sh video-editor   # build & serve the Video Editor → http://localhost:8080
+./dev.sh serve          # serve the example bundle      → http://localhost:8080
+./dev.sh help           # all commands
 ```
 
-### Or use Docker Compose directly
-
-```bash
-docker compose up --build test-native        # native test run
-docker compose up --build test-wasm          # WASM test run (Node)
-docker compose up serve-example              # http://localhost:8080
-docker compose up --build serve-algoviz      # http://localhost:8080
-docker compose up --build serve-video-editor # http://localhost:8080
-```
-
-## Building locally (no Docker)
-
-### Native (Linux / macOS)
-
-```bash
-cmake -B build/native -DCORTEX_BUILD_TESTS=ON
-cmake --build build/native
-ctest --test-dir build/native
-```
-
-### WebAssembly
-
-```bash
-source /path/to/emsdk/emsdk_env.sh
-emcmake cmake -B build/wasm -G Ninja -DCORTEX_BUILD_TESTS=ON
-cmake --build build/wasm
-ctest --test-dir build/wasm
-```
-
-### Build the browser demos
-
-```bash
-# AlgoViz
-emcmake cmake -B build/wasm-algoviz -G Ninja -DCORTEX_BUILD_APPS=ON
-cmake --build build/wasm-algoviz --target algo_viz
-
-# Video Editor
-emcmake cmake -B build/wasm-video-editor -G Ninja -DCORTEX_BUILD_APPS=ON
-cmake --build build/wasm-video-editor --target video_editor
-```
-
-Serve either bundle via any static HTTP server (`python3 -m http.server 8080`) from its build directory.
-
-### CMake options
-
-| Option | Default | Description |
-|---|---|---|
-| `CORTEX_BUILD_TESTS` | `ON` | Build the library + per-component test binaries (also builds the engine tests under `apps/video_editor`). |
-| `CORTEX_BUILD_EXAMPLES` | `OFF` | Build the standalone examples in `examples/`. |
-| `CORTEX_BUILD_APPS` | `OFF` | Build the full apps (`apps/algo_viz`, `apps/video_editor`). |
-| `CORTEX_USE_SANITIZERS` | `OFF` | Enable ASan + UBSan (and `BOOST_USE_ASAN` for Boost.Context). |
-
-## Project layout
-
-```
-include/cortex/             public headers (Coroutine, Generator, tiny_fiber/*)
-src/                        library implementation + per-platform PIMPL (Boost / Emscripten)
-tests/                      GoogleTest binaries for every library component
-examples/                   small WASM demos (one .cpp each + an HTML driver)
-apps/
-  algo_viz/                 interactive algorithm visualizer (BST, Union-Find)
-  video_editor/             real-time video editor — open a local file, filter every frame live in WASM
-    engine/                 layered engine library: filters, pipeline, runners, cooperative renderer (testable natively)
-    web/                    static HTML + modular JS (frame providers, playback loop, canvas, controls, …)
-cmake/                      build helpers, including the shared cortex_add_wasm_app_runtime()
-```
-
-## Requirements
-
-**With Docker** (recommended): only Docker and Docker Compose.
-
-**Without Docker:**
-- CMake 3.28+
-- C++23 compiler — Clang 19+ or GCC 13+
-- Ninja
-- Emscripten SDK 3.x (for WASM)
-- Node.js 18+ (to run WASM tests)
-
-## Development
-
-See [DEVELOPMENT.md](DEVELOPMENT.md) for the longer walkthrough, IDE setup (VSCode dev containers, CLion Docker toolchain), and the iterative-edit workflow.
+Building without Docker, the full CMake option list, and IDE setup live in **[DEVELOPMENT.md](DEVELOPMENT.md)**.
 
 ## License
 

--- a/apps/video_editor/CMakeLists.txt
+++ b/apps/video_editor/CMakeLists.txt
@@ -63,6 +63,12 @@ if(EMSCRIPTEN)
     )
     target_link_libraries(video_editor_runtime PRIVATE video_editor_engine)
 
+    # The per-pixel filter loops (brightness/contrast/saturation + separable blur)
+    # vectorize well — enable WASM SIMD for the engine (PUBLIC, so the runtime that
+    # links it inherits it too) and at link.
+    target_compile_options(video_editor_engine PUBLIC -msimd128)
+    target_link_options(video_editor_runtime PRIVATE -msimd128)
+
     add_custom_target(video_editor_assets
         COMMAND ${CMAKE_COMMAND} -E copy_directory
                 ${CMAKE_CURRENT_SOURCE_DIR}/web

--- a/apps/video_editor/engine/include/video_editor/live_cooperative.hpp
+++ b/apps/video_editor/engine/include/video_editor/live_cooperative.hpp
@@ -29,7 +29,11 @@ struct LiveFilterParams {
 // chain (verified in live_cooperative_test.cpp).
 class LiveCooperativeRenderer final {
 public:
-    explicit LiveCooperativeRenderer(int band_rows = 16);
+    // band_rows controls how many output rows are filtered between yields. Bigger
+    // bands mean fewer (cheaper-in-aggregate) fiber swaps per frame; the JS driver
+    // bounds per-tick work with its own time budget, so this is purely a swap-cost
+    // knob, not the responsiveness limit.
+    explicit LiveCooperativeRenderer(int band_rows = 32);
     ~LiveCooperativeRenderer();
 
     LiveCooperativeRenderer(const LiveCooperativeRenderer&) = delete;

--- a/apps/video_editor/engine/src/editor.cpp
+++ b/apps/video_editor/engine/src/editor.cpp
@@ -86,27 +86,33 @@ public:
     }
 
     void BeginCooperativeRender(int idx) {
-        coop_renderer_ = std::make_unique<LiveCooperativeRenderer>();
+        // Reuse the renderer (and its frame buffers) across frames; the editor
+        // begins a fresh cooperative render every displayed frame.
+        if (!coop_renderer_) {
+            coop_renderer_ = std::make_unique<LiveCooperativeRenderer>();
+        }
         coop_idx_ = idx;
+        coop_done_ = false;
         const LiveFilterParams params {brightness_, contrast_, saturation_, blur_radius_};
         coop_renderer_->Begin(source_->At(idx), params);
     }
 
     bool StepCooperative() {
-        if (!coop_renderer_) {
+        if (!coop_renderer_ || coop_done_) {
             return false;
         }
         const bool more = coop_renderer_->Step();
         if (!more) {
             // Publish the finished frame so Output(idx) / the bridge see it.
+            // Keep the renderer alive so the next frame's Begin reuses its buffers.
             pipeline_->WriteOutput(coop_idx_, coop_renderer_->Output());
-            coop_renderer_.reset();
+            coop_done_ = true;
         }
         return more;
     }
 
     bool CooperativeRenderDone() const noexcept {
-        return !coop_renderer_;
+        return coop_done_;
     }
 
     void StartCooperativeApply(IProgressListener& listener) {
@@ -176,6 +182,7 @@ private:
         // A live cooperative render writes into the pipeline output, so drop it
         // too before the pipeline is swapped out from under it.
         coop_renderer_.reset();
+        coop_done_ = true;
     }
 
     std::unique_ptr<IFrameSource> source_;
@@ -185,6 +192,7 @@ private:
     std::unique_ptr<IRunner> runner_;
     std::unique_ptr<LiveCooperativeRenderer> coop_renderer_;
     int coop_idx_ {0};
+    bool coop_done_ {true};
 
     float brightness_ {0.0f};
     float contrast_ {1.0f};

--- a/apps/video_editor/engine/src/live_cooperative.cpp
+++ b/apps/video_editor/engine/src/live_cooperative.cpp
@@ -155,16 +155,26 @@ void LiveCooperativeRenderer::Begin(const FrameBuffer& source, const LiveFilterP
     // Drop any in-flight render (tears the old scheduler down cleanly).
     scheduler_.reset();
 
-    auto state = std::make_shared<State>();
-    state->band_rows = band_rows_;
-    state->params = params;
-    state->work_a = source; // copy of the source frame
-    state->work_b = FrameBuffer(source.Width(), source.Height());
-    state->scratch = FrameBuffer(source.Width(), source.Height());
-    state->output = FrameBuffer(source.Width(), source.Height());
-    state_ = state;
+    const int w = source.Width();
+    const int h = source.Height();
+
+    // Reuse the frame buffers across renders; only (re)allocate when dimensions
+    // change. The editor begins a fresh cooperative render every displayed frame,
+    // so this keeps the real-time path allocation-free in steady state instead of
+    // allocating four full-frame buffers per frame.
+    if (!state_ || state_->work_a.Width() != w || state_->work_a.Height() != h) {
+        state_ = std::make_shared<State>();
+        state_->work_a = FrameBuffer(w, h);
+        state_->work_b = FrameBuffer(w, h);
+        state_->scratch = FrameBuffer(w, h);
+        state_->output = FrameBuffer(w, h);
+    }
+    state_->band_rows = band_rows_;
+    state_->params = params;
+    state_->work_a.CopyFrom(source);
     done_ = false;
 
+    auto state = state_;
     scheduler_ = tf::Scheduler::Create([state] {
         State& s = *state;
         FrameBuffer* cur = &s.work_a;

--- a/apps/video_editor/web/src/editor_app.js
+++ b/apps/video_editor/web/src/editor_app.js
@@ -106,32 +106,31 @@ export class EditorApp {
         this._progress.setStatus(`Opening "${file.name}"…`);
 
         const provider = new VideoProvider(file, { cap: this._working.cap });
-        let plan;
         try {
-            plan = await provider.open();
+            const plan = await provider.open();
+
+            if (!this._client.resetUploaded(plan.width, plan.height, 1)) {
+                provider.dispose();
+                this._progress.setStatus("Engine refused the uploaded source.");
+                return;
+            }
+
+            this._swapProvider(provider);
+            this._canvas.resize(plan.width, plan.height);
+            this._applyFilterValues();
+            provider.play();
+            this._timeline.setPlaying(true);
+            this._source.setInfo(`Opened "${file.name}" — ${plan.width}×${plan.height}`);
+            this._progress.set(1);
+            this._progress.setStatus("Editing live — move the sliders while it plays.");
         } catch (err) {
             provider.dispose();
             this._progress.setStatus(err.message || "Could not open this video.");
+        } finally {
+            // Always re-enable the UI and clear _busy, even if opening threw, so the
+            // editor can never get wedged with its controls disabled.
             this._finishOpen();
-            return;
         }
-
-        if (!this._client.resetUploaded(plan.width, plan.height, 1)) {
-            provider.dispose();
-            this._progress.setStatus("Engine refused the uploaded source.");
-            this._finishOpen();
-            return;
-        }
-
-        this._swapProvider(provider);
-        this._canvas.resize(plan.width, plan.height);
-        this._applyFilterValues();
-        provider.play();
-        this._timeline.setPlaying(true);
-        this._source.setInfo(`Opened "${file.name}" — ${plan.width}×${plan.height}`);
-        this._progress.set(1);
-        this._progress.setStatus("Editing live — move the sliders while it plays.");
-        this._finishOpen();
     }
 
     _useSample() {

--- a/apps/video_editor/web/src/frame_provider.js
+++ b/apps/video_editor/web/src/frame_provider.js
@@ -124,6 +124,11 @@ export class VideoProvider extends EventTarget {
         return !!this._video && "requestVideoFrameCallback" in this._video;
     }
     requestVideoFrame(cb) { return this._video.requestVideoFrameCallback(cb); }
+    cancelVideoFrame(handle) {
+        if (this._video && "cancelVideoFrameCallback" in this._video) {
+            this._video.cancelVideoFrameCallback(handle);
+        }
+    }
 
     dispose() {
         if (this._video) {
@@ -209,5 +214,6 @@ export class ProceduralProvider extends EventTarget {
 
     get hasVideoFrameCallback() { return false; }
     requestVideoFrame() {}
+    cancelVideoFrame() {}
     dispose() {}
 }

--- a/apps/video_editor/web/src/playback.js
+++ b/apps/video_editor/web/src/playback.js
@@ -21,6 +21,8 @@ export class Playback {
         this._running = false;
         this._dirty = true;       // force the first paint
         this._rafId = 0;
+        this._vfcHandle = 0;      // pending requestVideoFrameCallback handle
+        this._vfcProvider = null; // provider that owns the pending rVFC
 
         // Phase 2 (cooperative engine) hooks — inert until enabled.
         this._cooperative = false;
@@ -33,6 +35,15 @@ export class Playback {
         this._provider = provider;
         this._dirty = true;
         this._coopActive = false;
+        // Re-kick scheduling. A pending requestVideoFrameCallback is bound to the
+        // previous provider's <video>, which the caller is about to dispose — it
+        // would never fire and the loop would stall (this is why opening a second
+        // video used to hang until a page reload). Cancel it and schedule a fresh
+        // tick against the new provider.
+        if (this._running) {
+            this._cancelPending();
+            this._schedule();
+        }
     }
 
     setOnPosition(fn) { this._onPosition = fn || (() => {}); }
@@ -53,20 +64,33 @@ export class Playback {
 
     stop() {
         this._running = false;
-        if (this._rafId) {
-            cancelAnimationFrame(this._rafId);
-            this._rafId = 0;
-        }
+        this._cancelPending();
     }
 
     _schedule() {
         if (!this._running) return;
         const p = this._provider;
         if (p && p.hasVideoFrameCallback && p.playing) {
-            p.requestVideoFrame(() => this._tick());
+            this._vfcProvider = p;
+            this._vfcHandle = p.requestVideoFrame(() => { this._vfcHandle = 0; this._tick(); });
         } else {
-            this._rafId = requestAnimationFrame(() => this._tick());
+            this._rafId = requestAnimationFrame(() => { this._rafId = 0; this._tick(); });
         }
+    }
+
+    // Cancel whichever next-tick callback is currently pending (rAF or rVFC). The
+    // rVFC handle is cancelled on the provider that owns it, since it is tied to
+    // that provider's <video>.
+    _cancelPending() {
+        if (this._rafId) {
+            cancelAnimationFrame(this._rafId);
+            this._rafId = 0;
+        }
+        if (this._vfcHandle && this._vfcProvider) {
+            this._vfcProvider.cancelVideoFrame(this._vfcHandle);
+        }
+        this._vfcHandle = 0;
+        this._vfcProvider = null;
     }
 
     _tick() {
@@ -110,7 +134,12 @@ export class Playback {
             this._coopStallTicks = 0;
         }
 
-        const budgetMs = 8;
+        // Per-tick compute budget. ~12 ms uses most of a 60 fps frame while leaving
+        // headroom for the browser to paint and stay responsive. A bigger budget
+        // lets each frame's filtering finish in fewer ticks, keeping the cooperative
+        // path closer to the synchronous one on heavy blur (it is inherently a bit
+        // slower — it deliberately yields so the page never freezes).
+        const budgetMs = 12;
         const start = performance.now();
         let done = client.cooperativeDone();
         while (!done && performance.now() - start < budgetMs) {

--- a/cmake/AppRuntime.cmake
+++ b/cmake/AppRuntime.cmake
@@ -12,8 +12,11 @@ if(NOT EMSCRIPTEN)
     return()
 endif()
 
+# Release apps are compute-bound (e.g. the video editor's per-pixel filter math),
+# so optimize for speed (-O3), not size (-Os). This also drives Binaryen's
+# whole-module optimization of the Asyncify-instrumented code at link time.
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(_CORTEX_APP_OPT_FLAGS "-Os")
+    set(_CORTEX_APP_OPT_FLAGS "-O3")
     set(_CORTEX_APP_ASSERT_FLAG "-sASSERTIONS=0")
 else()
     set(_CORTEX_APP_OPT_FLAGS "-O0")


### PR DESCRIPTION
The video editor's cooperative engine ran slower than necessary in the browser. Three fixes, none of which change the byte-identical filter output (enforced by live_cooperative_test):

- Build Release WASM apps with -O3 instead of -Os, and add -msimd128 so the per-pixel filter math and separable blur vectorize.
- Reuse the cooperative renderer and its four frame buffers across displayed frames instead of reallocating them every frame.
- Raise the default yield band 16 -> 32 rows, halving fiber swaps per frame (the JS driver's time budget still bounds main-thread work).

Also tighten the README (lead with the no-freeze value prop + demos, move the build matrix / CMake options / IDE setup to DEVELOPMENT.md, and add the missing CORTEX_BUILD_APPS option there).

Verified: native 139/139 tests pass; WASM video_editor and algo_viz build clean in Release.